### PR TITLE
Updated versions of Lombok, ErrorProne, and Spotless.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <javac.version>9+181-r4173-1</javac.version>
 
         <!--Compiler plugins-->
-        <errorprone.version>2.5.1</errorprone.version>
-        <lombok.version>1.18.12</lombok.version>
+        <errorprone.version>2.10.0</errorprone.version>
+        <lombok.version>1.18.28</lombok.version>
 
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <spotbugs.version>4.0.3</spotbugs.version>
@@ -335,7 +335,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>2.30.0</version>
                 <configuration>
                     <formats>
                         <!-- you can define as many formats as you want, each is independent -->


### PR DESCRIPTION
Versions of ErrorProne and Spotless used are the final versions for Java 8