### PR TITLE
#185 Analyze package cycles

### DIFF
--- a/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
+++ b/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
@@ -51,7 +51,7 @@ public class GitLogReader implements AutoCloseable {
         git.close();
     }
 
-    public File getGitDir(File basedir) {
+    public static File getGitDir(File basedir) {
         FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder().findGitDir(basedir);
         return repositoryBuilder.getGitDir();
     }

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/CodebaseGraphDTO.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/CodebaseGraphDTO.java
@@ -3,6 +3,7 @@ package org.hjug.graphbuilder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class CodebaseGraphDTO {
 
     private final Graph<String, DefaultWeightedEdge> classReferencesGraph;
     private final Graph<String, DefaultWeightedEdge> packageReferencesGraph;
+    private final Map<DefaultWeightedEdge, Set<DefaultWeightedEdge>> classRelationshipsInPackageRelationship;
     // used for looking up files where classes reside
     private final Map<String, String> classToSourceFilePathMapping;
 
@@ -29,11 +31,13 @@ public class CodebaseGraphDTO {
     public CodebaseGraphDTO(
             Graph<String, DefaultWeightedEdge> classReferencesGraph,
             Graph<String, DefaultWeightedEdge> packageReferencesGraph,
+            Map<DefaultWeightedEdge, Set<DefaultWeightedEdge>> classRelationshipsInPackageRelationship,
             Map<String, String> classToSourceFilePathMapping,
             List<ClassDisharmony> classDisharmonies,
             List<MethodDisharmony> methodDisharmonies) {
         this.classReferencesGraph = classReferencesGraph;
         this.packageReferencesGraph = packageReferencesGraph;
+        this.classRelationshipsInPackageRelationship = classRelationshipsInPackageRelationship;
         this.classToSourceFilePathMapping = classToSourceFilePathMapping;
         this.classDisharmonies = classDisharmonies;
         this.methodDisharmonies = methodDisharmonies;

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/DependencyCollector.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/DependencyCollector.java
@@ -1,5 +1,7 @@
 package org.hjug.graphbuilder;
 
+import org.jgrapht.graph.DefaultWeightedEdge;
+
 // TODO: Revisit - I don't think this is really needed
 public interface DependencyCollector {
 
@@ -17,7 +19,7 @@ public interface DependencyCollector {
      * @param fromPackageName The package that depends on another
      * @param toPackageName The package being depended upon
      */
-    void addPackageDependency(String fromPackageName, String toPackageName);
+    DefaultWeightedEdge addPackageDependency(String fromPackageName, String toPackageName);
 
     /**
      * Records the source file location for a class

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
@@ -39,6 +39,8 @@ public class GraphDependencyCollector implements DependencyCollector {
             DefaultWeightedEdge edge = classReferencesGraph.getEdge(fromClassFqn, toClassFqn);
             classReferencesGraph.setEdgeWeight(edge, classReferencesGraph.getEdgeWeight(edge) + 1);
         }
+
+        addPackageDependency(getPackageFromFqn(fromClassFqn), getPackageFromFqn(toClassFqn));
     }
 
     @Override
@@ -56,6 +58,14 @@ public class GraphDependencyCollector implements DependencyCollector {
             DefaultWeightedEdge edge = packageReferencesGraph.getEdge(fromPackageName, toPackageName);
             packageReferencesGraph.setEdgeWeight(edge, packageReferencesGraph.getEdgeWeight(edge) + 1);
         }
+    }
+
+    protected String getPackageFromFqn(String fqn) {
+        if (!fqn.contains(".")) {
+            return "";
+        }
+        int lastIndex = fqn.lastIndexOf(".");
+        return fqn.substring(0, lastIndex);
     }
 
     @Override

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
@@ -1,11 +1,15 @@
 package org.hjug.graphbuilder;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
+@Slf4j
 public class GraphDependencyCollector implements DependencyCollector {
 
     @Getter
@@ -16,6 +20,10 @@ public class GraphDependencyCollector implements DependencyCollector {
 
     @Getter
     private final Set<String> packagesInCodebase = new HashSet<>();
+
+    @Getter
+    private final Map<DefaultWeightedEdge, Set<DefaultWeightedEdge>> classRelationshipsInPackageRelationship =
+            new HashMap<>();
 
     public GraphDependencyCollector(
             Graph<String, DefaultWeightedEdge> classReferencesGraph,
@@ -33,31 +41,51 @@ public class GraphDependencyCollector implements DependencyCollector {
         classReferencesGraph.addVertex(fromClassFqn);
         classReferencesGraph.addVertex(toClassFqn);
 
+        DefaultWeightedEdge classRelationship;
         if (!classReferencesGraph.containsEdge(fromClassFqn, toClassFqn)) {
-            classReferencesGraph.addEdge(fromClassFqn, toClassFqn);
+            classRelationship = classReferencesGraph.addEdge(fromClassFqn, toClassFqn);
         } else {
-            DefaultWeightedEdge edge = classReferencesGraph.getEdge(fromClassFqn, toClassFqn);
-            classReferencesGraph.setEdgeWeight(edge, classReferencesGraph.getEdgeWeight(edge) + 1);
+            classRelationship = classReferencesGraph.getEdge(fromClassFqn, toClassFqn);
+            classReferencesGraph.setEdgeWeight(
+                    classRelationship, classReferencesGraph.getEdgeWeight(classRelationship) + 1);
         }
 
-        addPackageDependency(getPackageFromFqn(fromClassFqn), getPackageFromFqn(toClassFqn));
+        DefaultWeightedEdge packageEdge = addPackageDependency(fromClassFqn, toClassFqn);
+
+        if (packageEdge != null) {
+            if (!classRelationshipsInPackageRelationship.containsKey(packageEdge)) {
+                classRelationshipsInPackageRelationship.put(packageEdge, new HashSet<>());
+            }
+
+            Set<DefaultWeightedEdge> packageRelationship = classRelationshipsInPackageRelationship.get(packageEdge);
+            packageRelationship.remove(classRelationship);
+            packageRelationship.add(classRelationship);
+        }
     }
 
     @Override
-    public void addPackageDependency(String fromPackageName, String toPackageName) {
+    public DefaultWeightedEdge addPackageDependency(String fromClassFqn, String toClassFqn) {
+        String fromPackageName = getPackageFromFqn(fromClassFqn);
+        String toPackageName = getPackageFromFqn(toClassFqn);
+
         if (fromPackageName.equals(toPackageName)) {
-            return;
+            return null;
         }
 
         packageReferencesGraph.addVertex(fromPackageName);
         packageReferencesGraph.addVertex(toPackageName);
 
+        DefaultWeightedEdge packageEdge;
         if (!packageReferencesGraph.containsEdge(fromPackageName, toPackageName)) {
-            packageReferencesGraph.addEdge(fromPackageName, toPackageName);
+            packageEdge = packageReferencesGraph.addEdge(fromPackageName, toPackageName);
         } else {
-            DefaultWeightedEdge edge = packageReferencesGraph.getEdge(fromPackageName, toPackageName);
-            packageReferencesGraph.setEdgeWeight(edge, packageReferencesGraph.getEdgeWeight(edge) + 1);
+            packageEdge = packageReferencesGraph.getEdge(fromPackageName, toPackageName);
+            packageReferencesGraph.setEdgeWeight(packageEdge, packageReferencesGraph.getEdgeWeight(packageEdge) + 1);
         }
+
+        log.warn("Package dependency: {} -> {}", fromClassFqn, toClassFqn);
+
+        return packageEdge;
     }
 
     protected String getPackageFromFqn(String fqn) {

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/GraphDependencyCollector.java
@@ -83,8 +83,6 @@ public class GraphDependencyCollector implements DependencyCollector {
             packageReferencesGraph.setEdgeWeight(packageEdge, packageReferencesGraph.getEdgeWeight(packageEdge) + 1);
         }
 
-        log.warn("Package dependency: {} -> {}", fromClassFqn, toClassFqn);
-
         return packageEdge;
     }
 

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/JavaGraphBuilder.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/JavaGraphBuilder.java
@@ -99,6 +99,12 @@ public class JavaGraphBuilder {
         }
 
         removeClassesNotInCodebase(dependencyCollector.getPackagesInCodebase(), classReferencesGraph);
+        removePackagesNotInCodebase(dependencyCollector.getPackagesInCodebase(), packageReferencesGraph);
+        // remove class relationships that are not in the codebase that are in the package -> class relationship mapping
+        dependencyCollector
+                .getClassRelationshipsInPackageRelationship()
+                .keySet()
+                .retainAll(packageReferencesGraph.edgeSet());
 
         metricsCollector.finalizeMetrics();
         DisharmonyDetector detector = new DisharmonyDetector();
@@ -107,6 +113,7 @@ public class JavaGraphBuilder {
         return new CodebaseGraphDTO(
                 classReferencesGraph,
                 packageReferencesGraph,
+                dependencyCollector.getClassRelationshipsInPackageRelationship(),
                 javaVisitor.getClassToSourceFilePathMapping(), // hudson.model.FilePath ->
                 // file:///C:/Code/RefactorFirst/cost-benefit-calculator/hudson/model/FilePath.java
                 getClassDisharmonies(detector, metrics),
@@ -149,6 +156,20 @@ public class JavaGraphBuilder {
         }
 
         classReferencesGraph.removeAllVertices(classesToRemove);
+    }
+
+    void removePackagesNotInCodebase(
+            Set<String> packagesInCodebase, Graph<String, DefaultWeightedEdge> packageReferencesGraph) {
+
+        // collect nodes to remove
+        Set<String> packagesToRemove = new HashSet<>();
+        for (String aPackage : packageReferencesGraph.vertexSet()) {
+            if (!packagesInCodebase.contains(aPackage)) {
+                packagesToRemove.add(aPackage);
+            }
+        }
+
+        packageReferencesGraph.removeAllVertices(packagesToRemove);
     }
 
     String getPackage(String fqn) {

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/metrics/GraphMetricsCollector.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/metrics/GraphMetricsCollector.java
@@ -50,7 +50,7 @@ public class GraphMetricsCollector implements MetricsCollector {
     }
 
     @Override
-    public void addPackageDependency(String fromPackage, String toPackage) {
+    public DefaultWeightedEdge addPackageDependency(String fromPackage, String toPackage) {
         if (!packageGraph.containsVertex(fromPackage)) {
             packageGraph.addVertex(fromPackage);
         }
@@ -68,6 +68,8 @@ public class GraphMetricsCollector implements MetricsCollector {
             double weight = packageGraph.getEdgeWeight(edge);
             packageGraph.setEdgeWeight(edge, weight + 1.0);
         }
+
+        return edge;
     }
 
     @Override

--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/visitor/BaseTypeProcessor.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/visitor/BaseTypeProcessor.java
@@ -65,12 +65,4 @@ public abstract class BaseTypeProcessor {
             processAnnotation(ownerFqn, annotation, cursor);
         }
     }
-
-    protected String getPackageFromFqn(String fqn) {
-        if (!fqn.contains(".")) {
-            return "";
-        }
-        int lastIndex = fqn.lastIndexOf(".");
-        return fqn.substring(0, lastIndex);
-    }
 }

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
@@ -326,7 +326,7 @@ public class CostBenefitCalculator implements AutoCloseable {
         return cboClasses;
     }
 
-    public List<RankedDisharmony> calculateSourceNodeCostBenefitValues(
+    public List<RankedDisharmony> calculateRelationshipCostBenefitValues(
             Graph<String, DefaultWeightedEdge> classGraph,
             Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts,
             CodebaseGraphDTO dto,
@@ -352,6 +352,7 @@ public class CostBenefitCalculator implements AutoCloseable {
                     targetNodeShouldBeRemoved,
                     dto.getClassDisharmonyCountForClass(edgeSource),
                     dto.getClassDisharmonyCountForClass(edgeTarget));
+
             edgesThatNeedToBeRemoved.add(edgeThatNeedsToBeRemoved);
         }
 
@@ -383,8 +384,8 @@ public class CostBenefitCalculator implements AutoCloseable {
                 // then by weight, with lowest weight edges bubbling to the top
                 .thenComparingInt(RankedDisharmony::getEffortRank)
                 // then by disharmony count
-                .thenComparingInt(RankedDisharmony::getChangePronenessRank)
-                .thenComparingInt(RankedDisharmony::getEdgeTargetChangePronenessRank)
+                .thenComparingInt(RankedDisharmony::getEdgeSourceDisharmonyCount)
+                .thenComparingInt(RankedDisharmony::getEdgeTargetDisharmonyCount)
                 // then if the source node is in the list of nodes to be removed
                 // multiplying by -1 reverses the sort order (reverse doesn't work in chained comparators)
                 .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getSourceNodeShouldBeRemoved())

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/CycleRanker.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/CycleRanker.java
@@ -20,29 +20,24 @@ public class CycleRanker {
     private final String repositoryPath;
 
     @Getter
-    private Graph<String, DefaultWeightedEdge> classReferencesGraph;
-
-    @Getter
     private CodebaseGraphDTO codebaseGraphDTO;
 
-    public void generateClassReferencesGraph(boolean excludeTests, String testSourceDirectory) {
+    public CodebaseGraphDTO generateClassReferencesGraph(boolean excludeTests, String testSourceDirectory) {
         try {
             JavaGraphBuilder javaGraphBuilder = new JavaGraphBuilder();
-
             codebaseGraphDTO = javaGraphBuilder.getCodebaseGraphDTO(repositoryPath, excludeTests, testSourceDirectory);
-
-            classReferencesGraph = codebaseGraphDTO.getClassReferencesGraph();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        return codebaseGraphDTO;
     }
 
-    public List<RankedCycle> performCycleAnalysis(boolean excludeTests, String testSourceDirectory) {
-        List<RankedCycle> rankedCycles = new ArrayList<>();
+    public List<RankedCycle> performCycleAnalysis(Graph<String, DefaultWeightedEdge> graph) {
+        List<RankedCycle> rankedCycles;
         try {
             boolean calculateCycleChurn = false;
-            generateClassReferencesGraph(excludeTests, testSourceDirectory);
-            identifyRankedCycles(rankedCycles);
+            rankedCycles = new ArrayList<>(identifyRankedCycles(graph));
             sortRankedCycles(rankedCycles, calculateCycleChurn);
             setPriorities(rankedCycles);
         } catch (IOException e) {
@@ -52,7 +47,9 @@ public class CycleRanker {
         return rankedCycles;
     }
 
-    private void identifyRankedCycles(List<RankedCycle> rankedCycles) throws IOException {
+    private List<RankedCycle> identifyRankedCycles(Graph<String, DefaultWeightedEdge> classReferencesGraph)
+            throws IOException {
+        List<RankedCycle> rankedCycles = new ArrayList<>();
         CircularReferenceChecker<String, DefaultWeightedEdge> circularReferenceChecker =
                 new CircularReferenceChecker<>();
         Map<String, AsSubgraph<String, DefaultWeightedEdge>> cycles =
@@ -65,6 +62,8 @@ public class CycleRanker {
 
             rankedCycles.add(createRankedCycle(vertex, subGraph, cycleNodes, 0.0, new HashSet<>()));
         });
+
+        return rankedCycles;
     }
 
     public CycleNode classToCycleNode(String fqnClass) {

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/CycleRanker.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/CycleRanker.java
@@ -22,6 +22,7 @@ public class CycleRanker {
     @Getter
     private CodebaseGraphDTO codebaseGraphDTO;
 
+    // TODO: should this method belong in this class?
     public CodebaseGraphDTO generateClassReferencesGraph(boolean excludeTests, String testSourceDirectory) {
         try {
             JavaGraphBuilder javaGraphBuilder = new JavaGraphBuilder();
@@ -33,12 +34,10 @@ public class CycleRanker {
         return codebaseGraphDTO;
     }
 
-    public List<RankedCycle> performCycleAnalysis(Graph<String, DefaultWeightedEdge> graph) {
+    public List<RankedCycle> rankCycles(Graph<String, DefaultWeightedEdge> graph) {
         List<RankedCycle> rankedCycles;
         try {
-            boolean calculateCycleChurn = false;
             rankedCycles = new ArrayList<>(identifyRankedCycles(graph));
-            sortRankedCycles(rankedCycles, calculateCycleChurn);
             setPriorities(rankedCycles);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -60,7 +59,7 @@ public class CycleRanker {
                     //                        .peek(cycleNode -> log.info(cycleNode.toString()))
                     .collect(Collectors.toList());
 
-            rankedCycles.add(createRankedCycle(vertex, subGraph, cycleNodes, 0.0, new HashSet<>()));
+            rankedCycles.add(new RankedCycle(vertex, subGraph.vertexSet(), subGraph.edgeSet(), cycleNodes));
         });
 
         return rankedCycles;
@@ -81,30 +80,8 @@ public class CycleRanker {
         return fileRepoPath;
     }
 
-    private RankedCycle createRankedCycle(
-            String vertex,
-            AsSubgraph<String, DefaultWeightedEdge> subGraph,
-            List<CycleNode> cycleNodes,
-            double minCut,
-            Set<DefaultWeightedEdge> minCutEdges) {
-
-        return new RankedCycle(vertex, subGraph.vertexSet(), subGraph.edgeSet(), minCut, minCutEdges, cycleNodes);
-    }
-
-    private static void sortRankedCycles(List<RankedCycle> rankedCycles, boolean calculateChurnForCycles) {
-        if (calculateChurnForCycles) {
-            rankedCycles.sort(Comparator.comparing(RankedCycle::getAverageChangeProneness));
-
-            int cpr = 1;
-            for (RankedCycle rankedCycle : rankedCycles) {
-                rankedCycle.setChangePronenessRank(cpr++);
-            }
-        } else {
-            rankedCycles.sort(Comparator.comparing(RankedCycle::getRawPriority).reversed());
-        }
-    }
-
     private static void setPriorities(List<RankedCycle> rankedCycles) {
+        rankedCycles.sort(Comparator.comparing(RankedCycle::getRawPriority).reversed());
         int priority = 1;
         for (RankedCycle rankedCycle : rankedCycles) {
             rankedCycle.setPriority(priority++);

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedCycle.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedCycle.java
@@ -1,6 +1,5 @@
 package org.hjug.cbc;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
@@ -12,76 +11,19 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 public class RankedCycle {
 
     private final String cycleName;
-    private Integer changePronenessRankSum = 0;
 
     private final Set<String> vertexSet;
     private final Set<DefaultWeightedEdge> edgeSet;
-    private final double minCutCount;
-    private final Set<DefaultWeightedEdge> minCutEdges;
     private final List<CycleNode> cycleNodes;
-
     private float rawPriority;
     private Integer priority = 0;
-    private float averageChangeProneness;
-    private Integer changePronenessRank = 0;
-    private float impact;
 
     public RankedCycle(
-            String cycleName,
-            Set<String> vertexSet,
-            Set<DefaultWeightedEdge> edgeSet,
-            double minCutCount,
-            Set<DefaultWeightedEdge> minCutEdges,
-            List<CycleNode> cycleNodes) {
+            String cycleName, Set<String> vertexSet, Set<DefaultWeightedEdge> edgeSet, List<CycleNode> cycleNodes) {
         this.cycleNodes = cycleNodes;
         this.cycleName = cycleName;
         this.vertexSet = vertexSet;
         this.edgeSet = edgeSet;
-        this.minCutCount = minCutCount;
-
-        if (null == minCutEdges) {
-            this.minCutEdges = new HashSet<>();
-        } else {
-            this.minCutEdges = minCutEdges;
-        }
-
-        if (minCutCount == 0.0) {
-            this.impact = (float) (vertexSet.size());
-        } else {
-            this.impact = (float) (vertexSet.size() / minCutCount);
-        }
-
-        this.rawPriority = this.impact;
-    }
-
-    public RankedCycle(
-            String cycleName,
-            Integer changePronenessRankSum,
-            Set<String> vertexSet,
-            Set<DefaultWeightedEdge> edgeSet,
-            double minCutCount,
-            Set<DefaultWeightedEdge> minCutEdges,
-            List<CycleNode> cycleNodes) {
-        this.cycleNodes = cycleNodes;
-        this.cycleName = cycleName;
-        this.changePronenessRankSum = changePronenessRankSum;
-        this.vertexSet = vertexSet;
-        this.edgeSet = edgeSet;
-        this.minCutCount = minCutCount;
-
-        if (null == minCutEdges) {
-            this.minCutEdges = new HashSet<>();
-        } else {
-            this.minCutEdges = minCutEdges;
-        }
-
-        if (minCutCount == 0.0) {
-            this.impact = (float) (vertexSet.size());
-        } else {
-            this.impact = (float) (vertexSet.size() / minCutCount);
-        }
-
-        this.averageChangeProneness = (float) changePronenessRankSum / vertexSet.size();
-        this.rawPriority = this.impact + averageChangeProneness;
+        this.rawPriority = (float) (vertexSet.size()); // go away?
     }
 }

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
@@ -22,7 +22,7 @@ public class RankedDisharmony {
     private String fileName;
     private final String className;
     private final Integer effortRank;
-    private final Integer changePronenessRank;
+    private Integer changePronenessRank;
     private Integer rawPriority;
     private Integer priority = 0;
 
@@ -44,7 +44,8 @@ public class RankedDisharmony {
     private int sourceNodeShouldBeRemoved;
     private int targetNodeShouldBeRemoved;
     private String edgeTargetClass;
-    private Integer edgeTargetChangePronenessRank;
+    private Integer edgeSourceDisharmonyCount;
+    private Integer edgeTargetDisharmonyCount;
 
     public RankedDisharmony(GodClass godClass, ScmLogInfo scmLogInfo) {
         path = scmLogInfo.getPath();
@@ -100,6 +101,7 @@ public class RankedDisharmony {
         commitCount = scmLogInfo.getCommitCount();
     }
 
+    // TODO: Move to a separate class?
     public RankedDisharmony(
             String edgeSource,
             DefaultWeightedEdge edge,
@@ -113,8 +115,8 @@ public class RankedDisharmony {
         className = edgeSource;
         this.edge = edge;
         this.cycleCount = cycleCount;
-        changePronenessRank = Math.toIntExact(sourceDisharmonyCount);
-        edgeTargetChangePronenessRank = Math.toIntExact(targetDisharmonyCount);
+        edgeSourceDisharmonyCount = Math.toIntExact(sourceDisharmonyCount);
+        edgeTargetDisharmonyCount = Math.toIntExact(targetDisharmonyCount);
         effortRank = weight;
         this.sourceNodeShouldBeRemoved = sourceNodeShouldBeRemoved ? 1 : 0;
         this.targetNodeShouldBeRemoved = targetNodeShouldBeRemoved ? 1 : 0;

--- a/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
+++ b/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
@@ -105,7 +105,7 @@ class CostBenefitCalculatorTest {
     }
 
     @Test
-    void calculateSourceNodeCostBenefitValues_filtersMissingLogInfoAndAssignsPriority() throws Exception {
+    void calculateRelationshipCostBenefitValues_filtersMissingLogInfoAndAssignsPriority() throws Exception {
 
         writeFile(hudsonPath + "Dummy.java", "public class Dummy {}");
 
@@ -156,7 +156,7 @@ class CostBenefitCalculatorTest {
             CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
             when(dto.getClassDisharmonyCountForClass(any())).thenReturn(0L);
 
-            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateSourceNodeCostBenefitValues(
+            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
                     classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove);
 
             Assertions.assertEquals(2, disharmonies.size());
@@ -176,12 +176,12 @@ class CostBenefitCalculatorTest {
             Assertions.assertEquals(0, classC.getSourceNodeShouldBeRemoved());
             Assertions.assertEquals(1, classC.getTargetNodeShouldBeRemoved());
             Assertions.assertEquals(2, classC.getPriority().intValue());
-            Assertions.assertEquals(0, classC.getChangePronenessRank());
+            Assertions.assertEquals(0, classC.getEdgeSourceDisharmonyCount());
         }
     }
 
     @Test
-    void calculateSourceNodeCostBenefitValues_prefersHigherChangePronenessRank() throws Exception {
+    void calculateRelationshipCostBenefitValues_prefersHigherChangePronenessRank() throws Exception {
 
         writeFile(faceletsPath + "Placeholder.java", "public class Placeholder {}");
 
@@ -228,14 +228,14 @@ class CostBenefitCalculatorTest {
             CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
             when(dto.getClassDisharmonyCountForClass(any())).thenReturn(0L).thenReturn(1L);
 
-            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateSourceNodeCostBenefitValues(
+            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
                     classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove);
 
             Assertions.assertEquals(2, disharmonies.size());
-            Assertions.assertEquals(0, disharmonies.get(0).getChangePronenessRank());
+            Assertions.assertEquals(0, disharmonies.get(0).getEdgeSourceDisharmonyCount());
             Assertions.assertEquals(1, disharmonies.get(0).getPriority().intValue());
             Assertions.assertEquals(2, disharmonies.get(1).getPriority().intValue());
-            Assertions.assertEquals(1, disharmonies.get(1).getChangePronenessRank());
+            Assertions.assertEquals(1, disharmonies.get(1).getEdgeSourceDisharmonyCount());
         }
     }
 
@@ -297,7 +297,7 @@ class CostBenefitCalculatorTest {
                     + disharmony.getEffortRank() + " "
                     + disharmony.getSourceNodeShouldBeRemoved() + " "
                     + disharmony.getTargetNodeShouldBeRemoved() + " "
-                    + disharmony.getChangePronenessRank());
+                    + disharmony.getEdgeSourceDisharmonyCount());
         }
 
         RankedDisharmony orderedDisharmony0 = disharmonies.get(0);
@@ -306,7 +306,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony0.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony0.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony0.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(0, orderedDisharmony0.getChangePronenessRank());
+        Assertions.assertEquals(0, orderedDisharmony0.getEdgeSourceDisharmonyCount());
 
         RankedDisharmony orderedDisharmony1 = disharmonies.get(1);
         Assertions.assertEquals("Class2", orderedDisharmony1.getClassName());
@@ -314,7 +314,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony1.getEffortRank().intValue());
         Assertions.assertEquals(1, orderedDisharmony1.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony1.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(1, orderedDisharmony1.getChangePronenessRank());
+        Assertions.assertEquals(1, orderedDisharmony1.getEdgeSourceDisharmonyCount());
 
         RankedDisharmony orderedDisharmony2 = disharmonies.get(2);
         Assertions.assertEquals("Class3", orderedDisharmony2.getClassName());
@@ -322,7 +322,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony2.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony2.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(1, orderedDisharmony2.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(2, orderedDisharmony2.getChangePronenessRank());
+        Assertions.assertEquals(2, orderedDisharmony2.getEdgeSourceDisharmonyCount());
 
         RankedDisharmony orderedDisharmony3 = disharmonies.get(3);
         Assertions.assertEquals("Class5", orderedDisharmony3.getClassName());
@@ -330,7 +330,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony3.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony3.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony3.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(5, orderedDisharmony3.getChangePronenessRank());
+        Assertions.assertEquals(5, orderedDisharmony3.getEdgeSourceDisharmonyCount());
 
         RankedDisharmony orderedDisharmony4 = disharmonies.get(4);
         Assertions.assertEquals("Class4", orderedDisharmony4.getClassName());
@@ -338,7 +338,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(3, orderedDisharmony4.getCycleCount().intValue());
         Assertions.assertEquals(0, orderedDisharmony4.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony4.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(6, orderedDisharmony4.getChangePronenessRank());
+        Assertions.assertEquals(6, orderedDisharmony4.getEdgeSourceDisharmonyCount());
     }
 
     private void writeFile(String name, String content) throws IOException {

--- a/cost-benefit-calculator/src/test/java/org/hjug/cbc/DisharmonyChurnRankingTest.java
+++ b/cost-benefit-calculator/src/test/java/org/hjug/cbc/DisharmonyChurnRankingTest.java
@@ -252,6 +252,7 @@ class DisharmonyChurnRankingTest {
         return new CodebaseGraphDTO(
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
+                new HashMap<>(),
                 dtoFileMap,
                 List.of(),
                 List.of(d));

--- a/cost-benefit-calculator/src/test/java/org/hjug/cbc/DisharmonyExtractionTest.java
+++ b/cost-benefit-calculator/src/test/java/org/hjug/cbc/DisharmonyExtractionTest.java
@@ -172,6 +172,7 @@ class DisharmonyExtractionTest {
         return new CodebaseGraphDTO(
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
+                new HashMap<>(),
                 fileMap,
                 List.of(d),
                 List.of());
@@ -210,6 +211,7 @@ class DisharmonyExtractionTest {
         return new CodebaseGraphDTO(
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
                 new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class),
+                new HashMap<>(),
                 fileMap,
                 List.of(),
                 List.of(d));

--- a/graph-algorithms/src/main/java/org/hjug/feedback/CycleRemovalComputer.java
+++ b/graph-algorithms/src/main/java/org/hjug/feedback/CycleRemovalComputer.java
@@ -1,0 +1,60 @@
+package org.hjug.feedback;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.hjug.dsm.CircularReferenceChecker;
+import org.hjug.feedback.arc.pageRank.PageRankFAS;
+import org.hjug.feedback.vertex.kernelized.DirectedFeedbackVertexSetResult;
+import org.hjug.feedback.vertex.kernelized.DirectedFeedbackVertexSetSolver;
+import org.hjug.feedback.vertex.kernelized.EnhancedParameterComputer;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.AsSubgraph;
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+@Slf4j
+public class CycleRemovalComputer {
+
+    public CycleRemovalResult computeCycleRemovalInformation(Graph<String, DefaultWeightedEdge> graph) {
+        Map<String, AsSubgraph<String, DefaultWeightedEdge>> cycles =
+                new CircularReferenceChecker<String, DefaultWeightedEdge>().getCycles(graph);
+        Map<DefaultWeightedEdge, Integer> edgeCycleCounts = new HashMap<>();
+        Set<String> vertexesToRemove = new HashSet<>();
+        Set<DefaultWeightedEdge> edgesToRemove = new HashSet<>();
+
+        // Skip vertex and edge removal analysis if there are no cycles
+        if (!cycles.isEmpty()) {
+            // Identify vertexes to remove
+            log.info("Identifying vertexes to remove");
+            EnhancedParameterComputer<String, DefaultWeightedEdge> enhancedParameterComputer =
+                    new EnhancedParameterComputer<>(new SuperTypeToken<>() {});
+            EnhancedParameterComputer.EnhancedParameters<String> parameters =
+                    enhancedParameterComputer.computeOptimalParameters(graph, 4);
+            DirectedFeedbackVertexSetSolver<String, DefaultWeightedEdge> vertexSolver =
+                    new DirectedFeedbackVertexSetSolver<>(
+                            graph, parameters.getModulator(), null, parameters.getEta(), new SuperTypeToken<>() {});
+            DirectedFeedbackVertexSetResult<String> vertexSetResult = vertexSolver.solve(parameters.getK());
+            vertexesToRemove.addAll(vertexSetResult.getFeedbackVertices());
+
+            // Identify edges to remove
+            log.info("Identifying edges to remove");
+            PageRankFAS<String, DefaultWeightedEdge> pageRankFAS = new PageRankFAS<>(graph, new SuperTypeToken<>() {});
+            edgesToRemove.addAll(pageRankFAS.computeFeedbackArcSet());
+
+            // capture the number of cycles each edge to remove is in
+            for (DefaultWeightedEdge edgeToRemove : edgesToRemove) {
+                int cycleCount = 0;
+                for (AsSubgraph<String, DefaultWeightedEdge> cycle : cycles.values()) {
+                    if (cycle.containsEdge(edgeToRemove)) {
+                        cycleCount++;
+                    }
+                }
+                edgeCycleCounts.put(edgeToRemove, cycleCount);
+            }
+        }
+
+        return new CycleRemovalResult(cycles, edgesToRemove, vertexesToRemove, edgeCycleCounts);
+    }
+}

--- a/graph-algorithms/src/main/java/org/hjug/feedback/CycleRemovalResult.java
+++ b/graph-algorithms/src/main/java/org/hjug/feedback/CycleRemovalResult.java
@@ -1,0 +1,15 @@
+package org.hjug.feedback;
+
+import java.util.Map;
+import java.util.Set;
+import lombok.Data;
+import org.jgrapht.graph.AsSubgraph;
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+@Data
+public class CycleRemovalResult {
+    private final Map<String, AsSubgraph<String, DefaultWeightedEdge>> cycles;
+    private final Set<DefaultWeightedEdge> edgesToRemove;
+    private final Set<String> vertexesToRemove;
+    private final Map<DefaultWeightedEdge, Integer> edgeCycleCounts;
+}

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenReport.java
@@ -1,7 +1,6 @@
 package org.hjug.mavenreport;
 
 import java.util.*;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.doxia.markup.HtmlMarkup;

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -420,6 +420,7 @@ public class HtmlReport extends SimpleHtmlReport {
             List<RankedCycle> rankedCycles) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("<li><a href=\"#CLASSMAP\">Class Map</a></li>\n");
+        stringBuilder.append("<li><a href=\"#PACKAGEMAP\">Package Map</a></li>\n");
         stringBuilder.append(super.createMenu(disharmonySpecs, rankedDisharmoniesByAnchor, rankedCycles));
         return stringBuilder;
     }
@@ -477,6 +478,7 @@ public class HtmlReport extends SimpleHtmlReport {
         String classGraphName = "classGraph";
 
         StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("<h1 align=\"center\"><a id=\"CLASSMAP\">Class Map</a></h1>");
         stringBuilder.append(generateGraphButtons(classGraphName, dot));
 
         stringBuilder.append(
@@ -498,7 +500,6 @@ public class HtmlReport extends SimpleHtmlReport {
 
     private StringBuilder generateGraphButtons(String graphName, String dot) {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("<h1 align=\"center\"><a id=\"CLASSMAP\">Class Map</a></h1>");
         stringBuilder.append("<script>\n");
         stringBuilder.append("const " + graphName + "_dot = " + dot + "\n");
         stringBuilder.append("</script>\n");
@@ -549,7 +550,7 @@ public class HtmlReport extends SimpleHtmlReport {
         dot.append("`strict digraph G {\n");
 
         for (DefaultWeightedEdge edge : classGraph.edgeSet()) {
-            renderEdge(classGraph, edge, dot);
+            renderClassGraphEdge(classGraph, edge, dot);
         }
 
         // capture only classes that have a relationship with one or more other classes
@@ -605,7 +606,7 @@ public class HtmlReport extends SimpleHtmlReport {
         return sb.append("URL=\"" + repoUrl + path + "\" target=\"_blank\"").toString();
     }
 
-    private void renderEdge(
+    private void renderClassGraphEdge(
             Graph<String, DefaultWeightedEdge> classGraph, DefaultWeightedEdge edge, StringBuilder dot) {
         // render edge
         String[] vertexes = extractVertexes(edge);
@@ -653,12 +654,13 @@ public class HtmlReport extends SimpleHtmlReport {
     }
 
     @Override
-    public String renderCycleVisuals(RankedCycle cycle, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
-        String dot = buildCycleDot(classGraph, cycle, repoUrl, codebaseGraphDTO);
+    public String renderClassCycleVisuals(RankedCycle cycle, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        String dot = buildClassCycleDot(classGraph, cycle, repoUrl, codebaseGraphDTO);
 
         String cycleName = getClassName(cycle.getCycleName()).replace("$", "_");
 
         StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("<h1 align=\"center\">Cycle Map</h1>");
         stringBuilder.append(generateGraphButtons(cycleName, dot));
 
         if (cycle.getCycleNodes().size() + cycle.getEdgeSet().size() < dotGraphThreshold) {
@@ -674,7 +676,7 @@ public class HtmlReport extends SimpleHtmlReport {
         return stringBuilder.toString();
     }
 
-    String buildCycleDot(
+    String buildClassCycleDot(
             Graph<String, DefaultWeightedEdge> classGraph,
             RankedCycle cycle,
             String repoUrl,
@@ -683,7 +685,128 @@ public class HtmlReport extends SimpleHtmlReport {
         dot.append("`strict digraph G {\n");
 
         for (DefaultWeightedEdge edge : cycle.getEdgeSet()) {
-            renderEdge(classGraph, edge, dot);
+            renderClassGraphEdge(classGraph, edge, dot);
+        }
+
+        // render vertices
+        Set<String> vertexSet = cycle.getVertexSet();
+        renderClassVertices(classGraph, repoUrl, codebaseGraphDTO, vertexSet, dot);
+
+        dot.append("}`;");
+        return dot.toString();
+    }
+
+    @Override
+    public String renderPackageGraphVisuals(String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        String dot = buildPackageGraphDot(packageGraph, repoUrl, codebaseGraphDTO);
+        String packageGraphName = "packageGraph";
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("<h1 align=\"center\"><a id=\"PACKAGEMAP\">Package Map</a></h1>");
+        stringBuilder.append(generateGraphButtons(packageGraphName, dot));
+
+        stringBuilder.append(
+                "<div align=\"center\">Excludes packages that have no incoming and outgoing edges<br></div>");
+
+        int packageCount = packageGraph.vertexSet().size();
+        int relationshipCount = packageGraph.edgeSet().size();
+        stringBuilder.append("<div align=\"center\">Number of packages: " + packageCount + "  Number of relationships: "
+                + relationshipCount + "<br></div>");
+        if (packageCount + relationshipCount < dotGraphThreshold) {
+            stringBuilder.append(generateDotImage(packageGraphName));
+        } else {
+            // revisit and add DOT SVG popup button
+            stringBuilder.append("<div align=\"center\">\nSVG is too big to render quickly</div>\n");
+        }
+
+        return stringBuilder.toString();
+    }
+
+    String buildPackageGraphDot(
+            Graph<String, DefaultWeightedEdge> packageGraph, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        StringBuilder dot = new StringBuilder();
+        dot.append("`strict digraph G {\n");
+
+        for (DefaultWeightedEdge edge : packageGraph.edgeSet()) {
+            renderPackageGraphEdge(packageGraph, edge, dot);
+        }
+
+        // capture only classes that have a relationship with one or more other classes
+        Set<String> vertexesToRender = new HashSet<>();
+        for (DefaultWeightedEdge edge : packageGraph.edgeSet()) {
+            String[] vertexes = extractVertexes(edge);
+            vertexesToRender.add(vertexes[0].trim());
+            vertexesToRender.add(vertexes[1].trim());
+        }
+
+        // render vertices
+        renderPackageVertices(packageGraph, repoUrl, codebaseGraphDTO, vertexesToRender, dot);
+
+        dot.append("}`;");
+        return dot.toString();
+    }
+
+    private void renderPackageGraphEdge(
+            Graph<String, DefaultWeightedEdge> packageGraph, DefaultWeightedEdge edge, StringBuilder dot) {
+        // render edge
+        String[] vertexes = extractVertexes(edge);
+
+        String start = vertexes[0].trim().replace(".", "_");
+        String end = vertexes[1].trim().replace(".", "_");
+
+        log.debug("Rendering edge: {} -> {}", start, end);
+        dot.append(start);
+        dot.append(" -> ");
+        dot.append(end);
+
+        // render edge attributes
+        int edgeWeight = (int) packageGraph.getEdgeWeight(edge);
+        dot.append(" [ ");
+        dot.append("label = \"");
+        dot.append(edgeWeight);
+        dot.append("\" ");
+        dot.append("weight = \"");
+        dot.append(edgeWeight);
+        dot.append("\"");
+
+        if (packageRelationshipsToRemove.contains(edge)) {
+            dot.append(" color = \"red\"");
+        }
+
+        dot.append(" ];\n");
+    }
+
+    private void renderPackageVertices(
+            Graph<String, DefaultWeightedEdge> classGraph,
+            String repoUrl,
+            CodebaseGraphDTO codebaseGraphDTO,
+            Set<String> vertexesToRender,
+            StringBuilder dot) {
+        for (String packageName : vertexesToRender) {
+            dot.append(packageName.replace(".", "_"));
+
+            dot.append(" [label=\"");
+            dot.append(packageName);
+            dot.append("\"");
+
+            if (packagesToRemove.contains(packageName)) {
+                dot.append(" color=red style=filled");
+            }
+
+            dot.append("];\n");
+        }
+    }
+
+    String buildPackageDot(
+            Graph<String, DefaultWeightedEdge> classGraph,
+            RankedCycle cycle,
+            String repoUrl,
+            CodebaseGraphDTO codebaseGraphDTO) {
+        StringBuilder dot = new StringBuilder();
+        dot.append("`strict digraph G {\n");
+
+        for (DefaultWeightedEdge edge : cycle.getEdgeSet()) {
+            renderClassGraphEdge(classGraph, edge, dot);
         }
 
         // render vertices

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -695,6 +695,10 @@ public class HtmlReport extends SimpleHtmlReport {
 
     @Override
     public String renderPackageGraphVisuals(String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        if (packageGraph.edgeSet().isEmpty()) {
+            return "";
+        }
+
         String dot = buildPackageGraphDot(packageGraph, repoUrl, codebaseGraphDTO);
         String packageGraphName = "packageGraph";
 

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -561,13 +561,13 @@ public class HtmlReport extends SimpleHtmlReport {
         }
 
         // render vertices
-        renderVertices(classGraph, repoUrl, codebaseGraphDTO, vertexesToRender, dot);
+        renderClassVertices(classGraph, repoUrl, codebaseGraphDTO, vertexesToRender, dot);
 
         dot.append("}`;");
         return dot.toString();
     }
 
-    private void renderVertices(
+    private void renderClassVertices(
             Graph<String, DefaultWeightedEdge> classGraph,
             String repoUrl,
             CodebaseGraphDTO codebaseGraphDTO,
@@ -591,7 +591,7 @@ public class HtmlReport extends SimpleHtmlReport {
                 dot.append(" label=\"").append(className.replace("$", "\\$")).append("\"");
             }
 
-            if (vertexesToRemove.contains(vertex)) {
+            if (classesToRemove.contains(vertex)) {
                 dot.append(" color=red style=filled");
             }
 
@@ -645,7 +645,7 @@ public class HtmlReport extends SimpleHtmlReport {
         dot.append(edgeWeight);
         dot.append("\"");
 
-        if (edgesToRemove.contains(edge)) {
+        if (classRelationshipsToRemove.contains(edge)) {
             dot.append(" color = \"red\"");
         }
 
@@ -688,7 +688,7 @@ public class HtmlReport extends SimpleHtmlReport {
 
         // render vertices
         Set<String> vertexSet = cycle.getVertexSet();
-        renderVertices(classGraph, repoUrl, codebaseGraphDTO, vertexSet, dot);
+        renderClassVertices(classGraph, repoUrl, codebaseGraphDTO, vertexSet, dot);
 
         dot.append("}`;");
         return dot.toString();

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -413,16 +413,12 @@ public class HtmlReport extends SimpleHtmlReport {
         return "<title>Refactor First Report for " + projectName + " " + projectVersion + " </title>\n";
     }
 
-    @Override
-    StringBuilder createMenu(
-            List<DisharmonySpec> disharmonySpecs,
-            Map<String, List<RankedDisharmony>> rankedDisharmoniesByAnchor,
-            List<RankedCycle> rankedCycles) {
-        StringBuilder stringBuilder = new StringBuilder();
+    void renderClassMapMenu(StringBuilder stringBuilder) {
         stringBuilder.append("<li><a href=\"#CLASSMAP\">Class Map</a></li>\n");
+    }
+
+    void renderPackageMapMenu(StringBuilder stringBuilder) {
         stringBuilder.append("<li><a href=\"#PACKAGEMAP\">Package Map</a></li>\n");
-        stringBuilder.append(super.createMenu(disharmonySpecs, rankedDisharmoniesByAnchor, rankedCycles));
-        return stringBuilder;
     }
 
     @Override

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -482,7 +482,7 @@ public class HtmlReport extends SimpleHtmlReport {
         stringBuilder.append(generateGraphButtons(classGraphName, dot));
 
         stringBuilder.append(
-                "<div align=\"center\">Excludes classes that have no incoming and outgoing edges<br></div>");
+                "<div align=\"center\">Clicking on a node in the DOT graph (if present below) will open its source file in the repo.  Right/Alt click to open in a new browser tab.<br>Excludes classes that have no incoming and outgoing edges<br></div>");
 
         int classCount = classGraph.vertexSet().size();
         int relationshipCount = classGraph.edgeSet().size();
@@ -510,8 +510,6 @@ public class HtmlReport extends SimpleHtmlReport {
         stringBuilder.append("<div align=\"center\">\nRed lines represent relationships to remove.<br>\n");
         stringBuilder.append("Red nodes represent classes to remove.<br>\n");
         stringBuilder.append("Zoom in / out with your mouse wheel and click/move to drag the image.<br>\n");
-        stringBuilder.append(
-                "Clicking on a node in the DOT graph (if present below) will open its source file in the repo.  It will not open a new browser window.\n");
         stringBuilder.append("</div>\n");
         return stringBuilder;
     }
@@ -662,6 +660,9 @@ public class HtmlReport extends SimpleHtmlReport {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("<h1 align=\"center\">Cycle Map</h1>");
         stringBuilder.append(generateGraphButtons(cycleName, dot));
+
+        stringBuilder.append(
+                "<div align=\"center\">Clicking on a node in the DOT graph (if present below) will open its source file in the repo.  Right/Alt click to open in a new browser tab.<br></div>");
 
         if (cycle.getCycleNodes().size() + cycle.getEdgeSet().size() < dotGraphThreshold) {
             stringBuilder.append(generateDotImage(cycleName));

--- a/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/HtmlReport.java
@@ -797,26 +797,6 @@ public class HtmlReport extends SimpleHtmlReport {
         }
     }
 
-    String buildPackageDot(
-            Graph<String, DefaultWeightedEdge> classGraph,
-            RankedCycle cycle,
-            String repoUrl,
-            CodebaseGraphDTO codebaseGraphDTO) {
-        StringBuilder dot = new StringBuilder();
-        dot.append("`strict digraph G {\n");
-
-        for (DefaultWeightedEdge edge : cycle.getEdgeSet()) {
-            renderClassGraphEdge(classGraph, edge, dot);
-        }
-
-        // render vertices
-        Set<String> vertexSet = cycle.getVertexSet();
-        renderClassVertices(classGraph, repoUrl, codebaseGraphDTO, vertexSet, dot);
-
-        dot.append("}`;");
-        return dot.toString();
-    }
-
     String generate2DPopup(String cycleName) {
         // Created by generative AI and modified
         return "<button style=\"display: block; margin: 0 auto;\" onclick=\"showPopup('popup-" + cycleName

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -349,11 +349,13 @@ public class SimpleHtmlReport {
 
         if (!packageRelationshipsToRemove.isEmpty()) {
             menu.append("<li><a href=\"#\">Packages</a>\n" + "<ul>");
-            renderPackageMapMenu(menu);
+            if (!packageGraph.edgeSet().isEmpty()) {
+                renderPackageMapMenu(menu);
+            }
             menu.append("<li><a href=\"#PACKAGEEDGES\">Package Relationships To Remove</a></li>\n");
             menu.append("</ul>\n" + "</li>");
-        } else {
-            renderClassMapMenu(menu);
+        } else if (!packageGraph.edgeSet().isEmpty()) {
+            renderPackageMapMenu(menu);
         }
 
         if (!disharmonySpecs.isEmpty()) {

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -337,16 +337,27 @@ public class SimpleHtmlReport {
             Map<String, List<RankedDisharmony>> rankedDisharmoniesByAnchor,
             List<RankedCycle> rankedCycles) {
         StringBuilder menu = new StringBuilder();
+
         if (!classRelationshipsToRemove.isEmpty()) {
+            menu.append("<li><a href=\"#\">Classes</a>\n" + "<ul>");
+            renderClassMapMenu(menu);
             menu.append("<li><a href=\"#CLASSEDGES\">Class Relationships To Remove</a></li>\n");
+            menu.append("</ul>\n" + "</li>");
+        } else {
+            renderClassMapMenu(menu);
         }
 
         if (!packageRelationshipsToRemove.isEmpty()) {
+            menu.append("<li><a href=\"#\">Packages</a>\n" + "<ul>");
+            renderPackageMapMenu(menu);
             menu.append("<li><a href=\"#PACKAGEEDGES\">Package Relationships To Remove</a></li>\n");
+            menu.append("</ul>\n" + "</li>");
+        } else {
+            renderClassMapMenu(menu);
         }
 
         if (!disharmonySpecs.isEmpty()) {
-            menu.append("<li><a href=\"#\">Disharmonies</a>\n" + "                <ul>");
+            menu.append("<li><a href=\"#\">Disharmonies</a>\n" + "<ul>");
         }
 
         for (DisharmonySpec spec : disharmonySpecs) {
@@ -360,15 +371,21 @@ public class SimpleHtmlReport {
         }
 
         if (!disharmonySpecs.isEmpty()) {
-            menu.append("</ul>\n" + "            </li>");
+            menu.append("</ul>\n" + "</li>");
         }
 
         if (!rankedCycles.isEmpty()) {
+            menu.append("<li><a href=\"#\">Cycles</a>\n" + "<ul>");
             menu.append("<li><a href=\"#CYCLES\">Class Cycles</a></li>\n");
             menu.append("<li><a href=\"#CYCLEMAP\">Cycle Map</a></li>\n");
+            menu.append("</ul>\n" + "</li>");
         }
         return menu;
     }
+
+    void renderClassMapMenu(StringBuilder stringBuilder) {}
+
+    void renderPackageMapMenu(StringBuilder stringBuilder) {}
 
     private String renderCycles(List<RankedCycle> rankedCycles, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
         StringBuilder stringBuilder = new StringBuilder();

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -16,12 +16,8 @@ import java.util.regex.Pattern;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.hjug.cbc.*;
-import org.hjug.dsm.CircularReferenceChecker;
-import org.hjug.feedback.SuperTypeToken;
-import org.hjug.feedback.arc.pageRank.PageRankFAS;
-import org.hjug.feedback.vertex.kernelized.DirectedFeedbackVertexSetResult;
-import org.hjug.feedback.vertex.kernelized.DirectedFeedbackVertexSetSolver;
-import org.hjug.feedback.vertex.kernelized.EnhancedParameterComputer;
+import org.hjug.feedback.CycleRemovalComputer;
+import org.hjug.feedback.CycleRemovalResult;
 import org.hjug.git.GitLogReader;
 import org.hjug.graphbuilder.CodebaseGraphDTO;
 import org.hjug.graphbuilder.metrics.DisharmonyMetric;
@@ -50,9 +46,13 @@ public class SimpleHtmlReport {
     public final String[] classCycleTableHeadings = {"Classes", "Relationships"};
 
     Graph<String, DefaultWeightedEdge> classGraph;
+    Graph<String, DefaultWeightedEdge> packageGraph;
     Map<String, AsSubgraph<String, DefaultWeightedEdge>> classCycles;
-    Set<String> vertexesToRemove = Set.of(); // initialize for unit tests
-    Set<DefaultWeightedEdge> edgesToRemove = Set.of();
+    Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles;
+    Set<String> classesToRemove = Set.of(); // initialize for unit tests
+    Set<String> packagesToRemove = Set.of(); // initialize for unit tests
+    Set<DefaultWeightedEdge> classRelationshipsToRemove = Set.of();
+    Set<DefaultWeightedEdge> packageRelationshipsToRemove = Set.of();
 
     DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
             .withLocale(Locale.getDefault())
@@ -132,16 +132,14 @@ public class SimpleHtmlReport {
         stringBuilder.append(printBreadcrumbs());
         stringBuilder.append(printProjectHeader(projectName, projectVersion));
 
-        GitLogReader gitLogReader = new GitLogReader();
         String projectBaseDir;
         Optional<File> optionalGitDir;
-
         if (baseDir != null) {
             projectBaseDir = baseDir.getPath();
-            optionalGitDir = Optional.ofNullable(gitLogReader.getGitDir(baseDir));
+            optionalGitDir = Optional.ofNullable(GitLogReader.getGitDir(baseDir));
         } else {
             projectBaseDir = Paths.get("").toAbsolutePath().toString();
-            optionalGitDir = Optional.ofNullable(gitLogReader.getGitDir(new File(projectBaseDir)));
+            optionalGitDir = Optional.ofNullable(GitLogReader.getGitDir(new File(projectBaseDir)));
         }
 
         File gitDir;
@@ -174,55 +172,40 @@ public class SimpleHtmlReport {
 
         CycleRanker cycleRanker = new CycleRanker(projectBaseDir);
         List<RankedCycle> rankedClassCycles = List.of();
+        //        List<RankedCycle> rankedPackageCycles = List.of();
         CodebaseGraphDTO codebaseGraphDTO;
         if (analyzeCycles) {
             log.info("Analyzing Cycles");
             cycleRanker.generateClassReferencesGraph(excludeTests, testSourceDirectory);
             codebaseGraphDTO = cycleRanker.getCodebaseGraphDTO();
-            rankedClassCycles = cycleRanker.performCycleAnalysis(codebaseGraphDTO.getClassReferencesGraph());
+            rankedClassCycles = cycleRanker.rankCycles(codebaseGraphDTO.getClassReferencesGraph());
+            //            rankedPackageCycles = cycleRanker.rankCycles(codebaseGraphDTO.getPackageReferencesGraph());
         } else {
             codebaseGraphDTO = cycleRanker.generateClassReferencesGraph(excludeTests, testSourceDirectory);
         }
 
         classGraph = codebaseGraphDTO.getClassReferencesGraph();
-        classCycles = new CircularReferenceChecker<String, DefaultWeightedEdge>().getCycles(classGraph);
-        Map<DefaultWeightedEdge, Integer> edgeCycleCounts = new HashMap<>();
 
-        // Skip vertex and edge removal analysis if there are no cycles
-        if (!classCycles.isEmpty()) {
-            // Identify vertexes to remove
-            log.info("Identifying vertexes to remove");
-            EnhancedParameterComputer<String, DefaultWeightedEdge> enhancedParameterComputer =
-                    new EnhancedParameterComputer<>(new SuperTypeToken<>() {});
-            EnhancedParameterComputer.EnhancedParameters<String> parameters =
-                    enhancedParameterComputer.computeOptimalParameters(classGraph, 4);
-            DirectedFeedbackVertexSetSolver<String, DefaultWeightedEdge> vertexSolver =
-                    new DirectedFeedbackVertexSetSolver<>(
-                            classGraph,
-                            parameters.getModulator(),
-                            null,
-                            parameters.getEta(),
-                            new SuperTypeToken<>() {});
-            DirectedFeedbackVertexSetResult<String> vertexSetResult = vertexSolver.solve(parameters.getK());
-            vertexesToRemove = vertexSetResult.getFeedbackVertices();
+        CycleRemovalComputer cycleRemovalComputer = new CycleRemovalComputer();
 
-            // Identify edges to remove
-            log.info("Identifying edges to remove");
-            PageRankFAS<String, DefaultWeightedEdge> pageRankFAS =
-                    new PageRankFAS<>(classGraph, new SuperTypeToken<>() {});
-            edgesToRemove = pageRankFAS.computeFeedbackArcSet();
+        CycleRemovalResult classCycleRemovalResult = cycleRemovalComputer.computeCycleRemovalInformation(classGraph);
+        Map<DefaultWeightedEdge, Integer> classEdgeCycleCounts = classCycleRemovalResult.getEdgeCycleCounts();
+        classRelationshipsToRemove = classCycleRemovalResult.getEdgesToRemove();
+        classesToRemove = classCycleRemovalResult.getVertexesToRemove();
+        classCycles = classCycleRemovalResult.getCycles();
 
-            // capture the number of cycles each edge to remove is in
-            for (DefaultWeightedEdge edgeToRemove : edgesToRemove) {
-                int cycleCount = 0;
-                for (AsSubgraph<String, DefaultWeightedEdge> cycle : classCycles.values()) {
-                    if (cycle.containsEdge(edgeToRemove)) {
-                        cycleCount++;
-                    }
-                }
-                edgeCycleCounts.put(edgeToRemove, cycleCount);
-            }
+        packageGraph = codebaseGraphDTO.getPackageReferencesGraph();
+
+        for (DefaultWeightedEdge defaultWeightedEdge : packageGraph.edgeSet()) {
+            log.warn(defaultWeightedEdge.toString() + ": " + packageGraph.getEdgeWeight(defaultWeightedEdge));
         }
+
+        CycleRemovalResult packageCycleRemovalResult =
+                cycleRemovalComputer.computeCycleRemovalInformation(packageGraph);
+        Map<DefaultWeightedEdge, Integer> packageEdgeCycleCounts = packageCycleRemovalResult.getEdgeCycleCounts();
+        packageRelationshipsToRemove = packageCycleRemovalResult.getEdgesToRemove();
+        packagesToRemove = packageCycleRemovalResult.getVertexesToRemove();
+        packageCycles = packageCycleRemovalResult.getCycles();
 
         // Ordered (type, anchorId, displayTitle, isMethodLevel) for all disharmonies
         final List<DisharmonySpec> disharmonySpecs = List.of(
@@ -246,11 +229,14 @@ public class SimpleHtmlReport {
 
         log.info("Identifying Object Oriented Disharmonies");
 
-        List<RankedDisharmony> edgeDisharmonies = List.of();
+        List<RankedDisharmony> classRelationshipDisharmonies = List.of();
+        List<RankedDisharmony> packageRelationshipDisharmonies = List.of();
         try (CostBenefitCalculator costBenefitCalculator =
                 new CostBenefitCalculator(projectBaseDir, codebaseGraphDTO.getClassToSourceFilePathMapping())) {
-            edgeDisharmonies = costBenefitCalculator.calculateSourceNodeCostBenefitValues(
-                    classGraph, edgeCycleCounts, codebaseGraphDTO, vertexesToRemove);
+            classRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
+                    classGraph, classEdgeCycleCounts, codebaseGraphDTO, classesToRemove);
+            packageRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
+                    packageGraph, packageEdgeCycleCounts, codebaseGraphDTO, packagesToRemove);
 
             for (DisharmonySpec spec : disharmonySpecs) {
                 List<DisharmonyInstance> instances = spec.methodLevel()
@@ -273,8 +259,10 @@ public class SimpleHtmlReport {
         // - Edge weight
         // - Provide guidance on where to move the method if one is in the list to remove
 
-        boolean hasAnyDisharmony =
-                !edgesToRemove.isEmpty() || !rankedClassCycles.isEmpty() || !rankedDisharmoniesByAnchor.isEmpty();
+        boolean hasAnyDisharmony = !classRelationshipsToRemove.isEmpty()
+                || !packageRelationshipsToRemove.isEmpty()
+                || !rankedClassCycles.isEmpty()
+                || !rankedDisharmoniesByAnchor.isEmpty();
 
         String repoUrl;
         try (GitLogReader glr = new GitLogReader(new File(projectBaseDir))) {
@@ -305,9 +293,17 @@ public class SimpleHtmlReport {
         stringBuilder.append(renderGithubButtons());
 
         stringBuilder.append("<br/>\n");
-        if (!edgeDisharmonies.isEmpty()) {
-            stringBuilder.append(renderEdgeDisharmonies(edgeDisharmonies, repoUrl, codebaseGraphDTO));
+        if (!classRelationshipDisharmonies.isEmpty()) {
+            stringBuilder.append(renderClassEdgeDisharmonies(classRelationshipDisharmonies, repoUrl, codebaseGraphDTO));
             stringBuilder.append("<br/>\n" + "<br/>\n" + "<br/>\n" + "<br/>\n" + "<hr/>\n" + "<br/>\n" + "<br/>\n");
+        }
+
+        if (!packageRelationshipDisharmonies.isEmpty()) {
+            stringBuilder.append(
+                    renderPackageEdgeDisharmonies(packageRelationshipDisharmonies, repoUrl, codebaseGraphDTO));
+            stringBuilder.append("<br/>\n" + "<br/>\n" + "<br/>\n" + "<br/>\n" + "<hr/>\n" + "<br/>\n" + "<br/>\n");
+        } else {
+            log.info("No Package Relationship Disharmonies found");
         }
 
         for (DisharmonySpec spec : disharmonySpecs) {
@@ -332,7 +328,7 @@ public class SimpleHtmlReport {
             Map<String, List<RankedDisharmony>> rankedDisharmoniesByAnchor,
             List<RankedCycle> rankedCycles) {
         StringBuilder menu = new StringBuilder();
-        if (!edgesToRemove.isEmpty()) {
+        if (!classRelationshipsToRemove.isEmpty()) {
             menu.append("<li><a href=\"#EDGES\">Edges To Remove</a></li>\n");
         }
 
@@ -373,19 +369,22 @@ public class SimpleHtmlReport {
         return stringBuilder.toString();
     }
 
-    private String renderEdgeDisharmonies(
+    private String renderClassEdgeDisharmonies(
             List<RankedDisharmony> edgeDisharmonies, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(
-                "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Relationship Removal Priority</h1></a></div>\n");
+                "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Class Relationship Removal Priority</h1></a></div>\n");
         stringBuilder.append("<h2 align=\"center\">Refactor Starting with Priority 1</h2>\n");
         stringBuilder.append("<div style=\"text-align: center;\">\n");
-        stringBuilder.append("Current Cycle Count: ").append(classCycles.size()).append("<br>\n");
+        stringBuilder
+                .append("Current Class Cycle Count: ")
+                .append(classCycles.size())
+                .append("<br>\n");
 
         stringBuilder
                 .append("Number of Relationships to Remove: ")
-                .append(edgesToRemove.size())
+                .append(classRelationshipsToRemove.size())
                 .append("<br>\n");
         stringBuilder
                 .append("Classes with <strong>*</strong> should be broken apart")
@@ -396,7 +395,7 @@ public class SimpleHtmlReport {
         stringBuilder.append("<div align=\"center\">");
         stringBuilder.append("<table align=\"center\" border=\"5px\">\n");
         stringBuilder.append("<thead>\n<tr>\n");
-        for (String heading : getEdgeDisharmonyTableHeadings()) {
+        for (String heading : getClassRelationshipDisharmonyTableHeadings()) {
             stringBuilder.append("<th>").append(heading).append("</th>\n");
         }
         stringBuilder.append("</thead>\n");
@@ -406,7 +405,7 @@ public class SimpleHtmlReport {
         for (RankedDisharmony edge : edgeDisharmonies) {
             stringBuilder.append("<tr>\n");
 
-            for (String rowData : getEdgeDisharmony(edge, repoUrl, codebaseGraphDTO)) {
+            for (String rowData : getClassRelationshipDisharmony(edge, repoUrl, codebaseGraphDTO)) {
                 stringBuilder.append(drawTableCell(rowData));
             }
 
@@ -420,7 +419,74 @@ public class SimpleHtmlReport {
         return stringBuilder.toString();
     }
 
-    private String[] getEdgeDisharmonyTableHeadings() {
+    private String renderPackageEdgeDisharmonies(
+            List<RankedDisharmony> edgeDisharmonies, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        stringBuilder.append(
+                "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Package Relationship Removal Priority</h1></a></div>\n");
+        stringBuilder.append("<h2 align=\"center\">Refactor Starting with Priority 1</h2>\n");
+        stringBuilder.append("<div style=\"text-align: center;\">\n");
+        stringBuilder
+                .append("Current Package Cycle Count: ")
+                .append(packageCycles.size())
+                .append("<br>\n");
+
+        stringBuilder
+                .append("Number of Relationships to Remove: ")
+                .append(packageRelationshipsToRemove.size())
+                .append("<br>\n");
+        stringBuilder
+                .append("Packages with <strong>*</strong> should be broken apart")
+                .append("<br>\n");
+        stringBuilder.append("</div>\n");
+
+        // Content
+        stringBuilder.append("<div align=\"center\">");
+        stringBuilder.append("<table align=\"center\" border=\"5px\">\n");
+        stringBuilder.append("<thead>\n<tr>\n");
+        for (String heading : getPackageRelationshipDisharmonyTableHeadings()) {
+            stringBuilder.append("<th>").append(heading).append("</th>\n");
+        }
+        stringBuilder.append("</thead>\n");
+
+        stringBuilder.append("<tbody>\n");
+
+        for (RankedDisharmony edge : edgeDisharmonies) {
+            stringBuilder.append("<tr>\n");
+
+            for (String rowData : getPackageRelationshipDisharmony(edge, repoUrl, codebaseGraphDTO)) {
+                stringBuilder.append(drawTableCell(rowData));
+            }
+
+            stringBuilder.append("</tr>\n");
+        }
+
+        stringBuilder.append("</tbody>\n");
+        stringBuilder.append("</table>\n");
+        stringBuilder.append("</div>\n");
+
+        return stringBuilder.toString();
+    }
+
+    /*
+    when: com.parentPackage.package
+    then: com.parentPackage
+
+    when: com.package.ClassA
+    then: com.package
+    */
+    String getParentNamespace(String fqn) {
+        // handle no package
+        if (!fqn.contains(".")) {
+            return "";
+        }
+
+        int lastIndex = fqn.lastIndexOf(".");
+        return fqn.substring(0, lastIndex);
+    }
+
+    private String[] getClassRelationshipDisharmonyTableHeadings() {
         return new String[] {
             "Relationship",
             "Priority",
@@ -431,14 +497,31 @@ public class SimpleHtmlReport {
         };
     }
 
-    private String[] getEdgeDisharmony(RankedDisharmony edgeInfo, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+    private String[] getPackageRelationshipDisharmonyTableHeadings() {
         return new String[] {
-            renderEdge(edgeInfo.getEdge(), repoUrl, codebaseGraphDTO),
+            "Relationship", "Priority", "In Cycles", "Edge<br>Weight",
+        };
+    }
+
+    private String[] getClassRelationshipDisharmony(
+            RankedDisharmony edgeInfo, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        return new String[] {
+            renderClassEdge(edgeInfo.getEdge(), repoUrl, codebaseGraphDTO),
             String.valueOf(edgeInfo.getPriority()),
             String.valueOf(edgeInfo.getCycleCount()),
             String.valueOf(edgeInfo.getEffortRank()),
-            String.valueOf(edgeInfo.getChangePronenessRank()),
-            String.valueOf(edgeInfo.getEdgeTargetChangePronenessRank()),
+            String.valueOf(edgeInfo.getEdgeSourceDisharmonyCount()),
+            String.valueOf(edgeInfo.getEdgeTargetDisharmonyCount()),
+        };
+    }
+
+    private String[] getPackageRelationshipDisharmony(
+            RankedDisharmony edgeInfo, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        return new String[] {
+            renderPackageEdge(edgeInfo.getEdge(), repoUrl, codebaseGraphDTO),
+            String.valueOf(edgeInfo.getPriority()),
+            String.valueOf(edgeInfo.getCycleCount()),
+            String.valueOf(edgeInfo.getEffortRank()),
         };
     }
 
@@ -446,10 +529,6 @@ public class SimpleHtmlReport {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append("<div style=\"text-align: center;\"><a id=\"CYCLES\"><h1>Class Cycles</h1></a></div>\n");
-        /*if (rankedCycles.size() > 10) {
-            stringBuilder.append(
-                    "<div style=\"text-align: center;\">10 largest cycles are shown in the sections below</div>\n");
-        }*/
 
         stringBuilder.append("<h2 align=\"center\">Class Cycles by the numbers:</h2>\n");
         stringBuilder.append("<div align=\"center\">");
@@ -457,7 +536,7 @@ public class SimpleHtmlReport {
 
         // Content
         stringBuilder.append("<thead>\n<tr>\n");
-        for (String heading : getCycleSummaryTableHeadings()) {
+        for (String heading : getClassCycleSummaryTableHeadings()) {
             stringBuilder.append("<th>").append(heading).append("</th>\n");
         }
         stringBuilder.append("</thead>\n");
@@ -467,19 +546,19 @@ public class SimpleHtmlReport {
             stringBuilder.append("<tr>\n");
 
             StringBuilder edges = new StringBuilder();
-            for (DefaultWeightedEdge edge : cycle.getMinCutEdges()) {
+            for (DefaultWeightedEdge edge : cycle.getEdgeSet()) {
 
-                if (edgesToRemove.contains(edge)) {
+                if (classRelationshipsToRemove.contains(edge)) {
                     stringBuilder.append("<strong>");
-                    edges.append(renderEdge(edge));
+                    edges.append(renderClassEdge(edge));
                     stringBuilder.append("</strong>");
                 } else {
-                    edges.append(renderEdge(edge));
+                    edges.append(renderClassEdge(edge));
                 }
                 edges.append("</br>\n");
             }
 
-            for (String rowData : getRankedCycleSummaryData(cycle, edges)) {
+            for (String rowData : getRankedCycleSummaryData(cycle)) {
                 stringBuilder.append(drawTableCell(rowData));
             }
 
@@ -492,13 +571,13 @@ public class SimpleHtmlReport {
         return stringBuilder.toString();
     }
 
-    private String renderEdge(DefaultWeightedEdge edge) {
+    private String renderClassEdge(DefaultWeightedEdge edge) {
         StringBuilder edgesToCut = new StringBuilder();
         String[] vertexes = extractVertexes(edge);
 
         String startVertex = vertexes[0].trim();
         String start;
-        if (vertexesToRemove.contains(startVertex)) {
+        if (classesToRemove.contains(startVertex)) {
             start = "<strong>" + getClassName(startVertex) + "</strong>";
         } else {
             start = getClassName(startVertex);
@@ -506,7 +585,7 @@ public class SimpleHtmlReport {
 
         String endVertex = vertexes[1].trim();
         String end;
-        if (vertexesToRemove.contains(endVertex)) {
+        if (classesToRemove.contains(endVertex)) {
             end = "<strong>" + getClassName(endVertex) + "</strong>";
         } else {
             end = getClassName(endVertex);
@@ -518,13 +597,13 @@ public class SimpleHtmlReport {
                 .toString();
     }
 
-    private String renderEdge(DefaultWeightedEdge edge, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+    private String renderClassEdge(DefaultWeightedEdge edge, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
         StringBuilder edgesToCut = new StringBuilder();
         String[] vertexes = extractVertexes(edge);
 
         String startVertex = vertexes[0].trim();
         String start;
-        if (vertexesToRemove.contains(startVertex)) {
+        if (classesToRemove.contains(startVertex)) {
             start = hyperlinkClass(startVertex, repoUrl, codebaseGraphDTO) + "<strong>*</strong>";
         } else {
             start = hyperlinkClass(startVertex, repoUrl, codebaseGraphDTO);
@@ -532,7 +611,7 @@ public class SimpleHtmlReport {
 
         String endVertex = vertexes[1].trim();
         String end;
-        if (vertexesToRemove.contains(endVertex)) {
+        if (classesToRemove.contains(endVertex)) {
             end = hyperlinkClass(endVertex, repoUrl, codebaseGraphDTO) + "<strong>*</strong>";
         } else {
             end = hyperlinkClass(endVertex, repoUrl, codebaseGraphDTO);
@@ -544,6 +623,32 @@ public class SimpleHtmlReport {
                 .toString();
     }
 
+    private String renderPackageEdge(DefaultWeightedEdge edge, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        StringBuilder edgesToCut = new StringBuilder();
+        String[] vertexes = extractVertexes(edge);
+
+        String startVertex = vertexes[0].trim();
+        String start;
+        if (packagesToRemove.contains(startVertex)) {
+            start = startVertex + "<strong>*</strong>";
+        } else {
+            start = startVertex;
+        }
+
+        String endVertex = vertexes[1].trim();
+        String end;
+        if (packagesToRemove.contains(endVertex)) {
+            end = endVertex + "<strong>*</strong>";
+        } else {
+            end = endVertex;
+        }
+
+        // &#8594; is HTML "Right Arrow" code
+        return edgesToCut
+                .append(start + " &#8594; " + end + " : " + (int) packageGraph.getEdgeWeight(edge))
+                .toString();
+    }
+
     String hyperlinkClass(String className, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
         StringBuilder sb = new StringBuilder();
         String path = codebaseGraphDTO.getClassToSourceFilePathMapping().get(className);
@@ -551,13 +656,13 @@ public class SimpleHtmlReport {
                 .toString();
     }
 
-    private String[] getCycleSummaryTableHeadings() {
-        return new String[] {"Cycle Name", "Priority", "Class Count", "Relationship Count" /*, "Minimum Cuts"*/};
+    private String[] getClassCycleSummaryTableHeadings() {
+        return new String[] {"Cycle Name", "Priority", "Class Count", "Relationship Count"};
     }
 
-    private String[] getRankedCycleSummaryData(RankedCycle rankedCycle, StringBuilder edgesToCut) {
+    private String[] getRankedCycleSummaryData(RankedCycle rankedCycle) {
         return new String[] {
-            // "Cycle Name", "Priority", "Class Count", "Relationship Count", "Min Cuts"
+            // "Cycle Name", "Priority", "Class Count", "Relationship Count"
             getClassName(rankedCycle.getCycleName()),
             rankedCycle.getPriority().toString(),
             String.valueOf(rankedCycle.getCycleNodes().size()),
@@ -606,7 +711,7 @@ public class SimpleHtmlReport {
         for (String vertex : cycle.getVertexSet()) {
             stringBuilder.append("<tr>");
             String className;
-            if (vertexesToRemove.contains(vertex)) {
+            if (classesToRemove.contains(vertex)) {
                 className = hyperlinkClass(vertex, repoUrl, codebaseGraphDTO) + "<strong>*</strong>";
             } else {
                 className = hyperlinkClass(vertex, repoUrl, codebaseGraphDTO);
@@ -617,12 +722,12 @@ public class SimpleHtmlReport {
             for (DefaultWeightedEdge edge : cycle.getEdgeSet()) {
                 if (edge.toString().startsWith("(" + vertex + " :")) {
 
-                    if (edgesToRemove.contains(edge)) {
+                    if (classRelationshipsToRemove.contains(edge)) {
                         edges.append("<strong>");
-                        edges.append(renderEdge(edge));
+                        edges.append(renderClassEdge(edge));
                         edges.append("</strong>");
                     } else {
-                        edges.append(renderEdge(edge));
+                        edges.append(renderClassEdge(edge));
                     }
 
                     edges.append("<br/>\n");
@@ -716,7 +821,14 @@ public class SimpleHtmlReport {
     }
 
     String renderGithubButtons() {
-        return ""; // empty on purpose
+        return "<div align=\"center\">\n" + "Show RefactorFirst some &#10084;&#65039;\n"
+                + "<br/>\n"
+                + "<a href=\"https://github.com/refactorfirst/refactorfirst\" aria-label=\"Star refactorfirst/refactorfirst on GitHub\">Star</a>\n"
+                + "<a href=\"https://github.com/refactorfirst/refactorfirst/fork\" aria-label=\"Fork refactorfirst/refactorfirst on GitHub\">Fork</a>\n"
+                + "<a href=\"https://github.com/refactorfirst/refactorfirst/subscription\" aria-label=\"Watch refactorfirst/refactorfirst on GitHub\">Watch</a>\n"
+                + "<a href=\"https://github.com/refactorfirst/refactorfirst/issues\" aria-label=\"Issue refactorfirst/refactorfirst on GitHub\">Issue</a>\n"
+                + "<a href=\"https://github.com/sponsors/jimbethancourt\" aria-label=\"Sponsor @jimbethancourt on GitHub\">Sponsor</a>\n"
+                + "</div>";
     }
 
     String getOutputName() {

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -383,7 +383,7 @@ public class SimpleHtmlReport {
                 .append("<br>\n");
 
         stringBuilder
-                .append("Number of Relationships to Remove: ")
+                .append("Number of Class Relationships to Remove: ")
                 .append(classRelationshipsToRemove.size())
                 .append("<br>\n");
         stringBuilder
@@ -433,7 +433,7 @@ public class SimpleHtmlReport {
                 .append("<br>\n");
 
         stringBuilder
-                .append("Number of Relationships to Remove: ")
+                .append("Number of Package Relationships to Remove: ")
                 .append(packageRelationshipsToRemove.size())
                 .append("<br>\n");
         stringBuilder
@@ -469,23 +469,6 @@ public class SimpleHtmlReport {
         return stringBuilder.toString();
     }
 
-    /*
-    when: com.parentPackage.package
-    then: com.parentPackage
-
-    when: com.package.ClassA
-    then: com.package
-    */
-    String getParentNamespace(String fqn) {
-        // handle no package
-        if (!fqn.contains(".")) {
-            return "";
-        }
-
-        int lastIndex = fqn.lastIndexOf(".");
-        return fqn.substring(0, lastIndex);
-    }
-
     private String[] getClassRelationshipDisharmonyTableHeadings() {
         return new String[] {
             "Relationship",
@@ -499,7 +482,7 @@ public class SimpleHtmlReport {
 
     private String[] getPackageRelationshipDisharmonyTableHeadings() {
         return new String[] {
-            "Relationship", "Priority", "In Cycles", "Edge<br>Weight",
+            "Package Relationship", "Priority", "In Cycles", "Edge<br>Weight", "Class Relationships",
         };
     }
 
@@ -517,11 +500,20 @@ public class SimpleHtmlReport {
 
     private String[] getPackageRelationshipDisharmony(
             RankedDisharmony edgeInfo, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+
+        Set<DefaultWeightedEdge> classRelationshipsInPackageRelationship =
+                codebaseGraphDTO.getClassRelationshipsInPackageRelationship().get(edgeInfo.getEdge());
+        Set<String> classEdges = new HashSet<>();
+        for (DefaultWeightedEdge defaultWeightedEdge : classRelationshipsInPackageRelationship) {
+            classEdges.add(renderClassEdge(defaultWeightedEdge, repoUrl, codebaseGraphDTO));
+        }
+
         return new String[] {
             renderPackageEdge(edgeInfo.getEdge(), repoUrl, codebaseGraphDTO),
             String.valueOf(edgeInfo.getPriority()),
             String.valueOf(edgeInfo.getCycleCount()),
             String.valueOf(edgeInfo.getEffortRank()),
+            String.join("<br>", classEdges),
         };
     }
 

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -298,6 +298,10 @@ public class SimpleHtmlReport {
             stringBuilder.append("<br/>\n" + "<br/>\n" + "<br/>\n" + "<br/>\n" + "<hr/>\n" + "<br/>\n" + "<br/>\n");
         }
 
+        stringBuilder.append(renderPackageGraphVisuals(repoUrl, codebaseGraphDTO));
+        stringBuilder.append("<br/>\n");
+        stringBuilder.append(renderGithubButtons());
+
         if (!packageRelationshipDisharmonies.isEmpty()) {
             stringBuilder.append(
                     renderPackageEdgeDisharmonies(packageRelationshipDisharmonies, repoUrl, codebaseGraphDTO));
@@ -675,7 +679,7 @@ public class SimpleHtmlReport {
                 + getClassName(cycle.getCycleName()) + "</h2></a>\n");
         stringBuilder.append(
                 "<h3 align=\"center\">Limiting number of cycles displayed to 1 to keep page load time fast</h3>\n");
-        stringBuilder.append(renderCycleVisuals(cycle, repoUrl, codebaseGraphDTO));
+        stringBuilder.append(renderClassCycleVisuals(cycle, repoUrl, codebaseGraphDTO));
 
         stringBuilder.append("<div align=\"center\">");
         stringBuilder.append("<strong>");
@@ -740,7 +744,11 @@ public class SimpleHtmlReport {
         return ""; // empty on purpose
     }
 
-    public String renderCycleVisuals(RankedCycle cycle, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+    public String renderPackageGraphVisuals(String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        return ""; // empty on purpose
+    }
+
+    public String renderClassCycleVisuals(RankedCycle cycle, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
         return ""; // empty on purpose
     }
 

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -126,12 +126,6 @@ public class SimpleHtmlReport {
             testSourceDirectory = "src" + File.separator + "test";
         }
 
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(printOpenBodyTag());
-        stringBuilder.append(printScripts());
-        stringBuilder.append(printBreadcrumbs());
-        stringBuilder.append(printProjectHeader(projectName, projectVersion));
-
         String projectBaseDir;
         Optional<File> optionalGitDir;
         if (baseDir != null) {
@@ -141,6 +135,12 @@ public class SimpleHtmlReport {
             projectBaseDir = Paths.get("").toAbsolutePath().toString();
             optionalGitDir = Optional.ofNullable(GitLogReader.getGitDir(new File(projectBaseDir)));
         }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(printOpenBodyTag());
+        stringBuilder.append(printScripts());
+        stringBuilder.append(printBreadcrumbs());
+        stringBuilder.append(printProjectHeader(projectName, projectVersion, projectBaseDir));
 
         File gitDir;
         if (optionalGitDir.isPresent()) {
@@ -264,10 +264,7 @@ public class SimpleHtmlReport {
                 || !rankedClassCycles.isEmpty()
                 || !rankedDisharmoniesByAnchor.isEmpty();
 
-        String repoUrl;
-        try (GitLogReader glr = new GitLogReader(new File(projectBaseDir))) {
-            repoUrl = glr.getOriginUrl().replace(".git", "") + "/blob/" + glr.getCurrentCommitHash() + "/";
-        }
+        String repoUrl = getRepoUrl(projectBaseDir);
 
         if (!hasAnyDisharmony) {
             stringBuilder
@@ -327,13 +324,25 @@ public class SimpleHtmlReport {
         return stringBuilder;
     }
 
+    private static String getRepoUrl(String projectBaseDir) throws Exception {
+        String repoUrl;
+        try (GitLogReader glr = new GitLogReader(new File(projectBaseDir))) {
+            repoUrl = glr.getOriginUrl().replace(".git", "") + "/blob/" + glr.getCurrentCommitHash() + "/";
+        }
+        return repoUrl;
+    }
+
     StringBuilder createMenu(
             List<DisharmonySpec> disharmonySpecs,
             Map<String, List<RankedDisharmony>> rankedDisharmoniesByAnchor,
             List<RankedCycle> rankedCycles) {
         StringBuilder menu = new StringBuilder();
         if (!classRelationshipsToRemove.isEmpty()) {
-            menu.append("<li><a href=\"#EDGES\">Edges To Remove</a></li>\n");
+            menu.append("<li><a href=\"#CLASSEDGES\">Class Relationships To Remove</a></li>\n");
+        }
+
+        if (!packageRelationshipsToRemove.isEmpty()) {
+            menu.append("<li><a href=\"#PACKAGEEDGES\">Package Relationships To Remove</a></li>\n");
         }
 
         if (!disharmonySpecs.isEmpty()) {
@@ -378,7 +387,7 @@ public class SimpleHtmlReport {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(
-                "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Class Relationship Removal Priority</h1></a></div>\n");
+                "<div style=\"text-align: center;\"><a id=\"CLASSEDGES\"><h1>Class Relationship Removal Priority</h1></a></div>\n");
         stringBuilder.append("<h2 align=\"center\">Refactor Starting with Priority 1</h2>\n");
         stringBuilder.append("<div style=\"text-align: center;\">\n");
         stringBuilder
@@ -428,7 +437,7 @@ public class SimpleHtmlReport {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(
-                "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Package Relationship Removal Priority</h1></a></div>\n");
+                "<div style=\"text-align: center;\"><a id=\"PACKAGEEDGES\"><h1>Package Relationship Removal Priority</h1></a></div>\n");
         stringBuilder.append("<h2 align=\"center\">Refactor Starting with Priority 1</h2>\n");
         stringBuilder.append("<div style=\"text-align: center;\">\n");
         stringBuilder
@@ -799,17 +808,18 @@ public class SimpleHtmlReport {
                 + "      <div class=\"xleft\">\n";
     }
 
-    public String printProjectHeader(String projectName, String projectVersion) {
+    public String printProjectHeader(String projectName, String projectVersion, String projectBaseDir)
+            throws Exception {
+        String repoUrl = getRepoUrl(projectBaseDir);
+
         return "</div>\n" + "      <div class=\"xright\">      </div>\n"
                 + "    </div>\n"
                 + "    <div id=\"bodyColumn\">\n"
                 + "      <div id=\"contentBox\">\n"
                 + "<h2 align=\"center\"><a href=\"https://github.com/refactorfirst/refactorfirst\" target=\"_blank\" "
                 + "title=\"Learn about RefactorFirst\" aria-label=\"RefactorFirst\">RefactorFirst</a> Report for "
-                + projectName
-                + " "
-                + projectVersion
-                + "</h2>\n";
+                + "<a href=" + repoUrl + " target=\"_blank\">" + projectName + " "
+                + projectVersion + "</a></h2>\n";
     }
 
     public String printProjectFooter() {

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -50,7 +50,7 @@ public class SimpleHtmlReport {
     public final String[] classCycleTableHeadings = {"Classes", "Relationships"};
 
     Graph<String, DefaultWeightedEdge> classGraph;
-    Map<String, AsSubgraph<String, DefaultWeightedEdge>> cycles;
+    Map<String, AsSubgraph<String, DefaultWeightedEdge>> classCycles;
     Set<String> vertexesToRemove = Set.of(); // initialize for unit tests
     Set<DefaultWeightedEdge> edgesToRemove = Set.of();
 
@@ -173,19 +173,23 @@ public class SimpleHtmlReport {
         }
 
         CycleRanker cycleRanker = new CycleRanker(projectBaseDir);
-        List<RankedCycle> rankedCycles = List.of();
+        List<RankedCycle> rankedClassCycles = List.of();
+        CodebaseGraphDTO codebaseGraphDTO;
         if (analyzeCycles) {
             log.info("Analyzing Cycles");
-            rankedCycles = cycleRanker.performCycleAnalysis(excludeTests, testSourceDirectory);
-        } else {
             cycleRanker.generateClassReferencesGraph(excludeTests, testSourceDirectory);
+            codebaseGraphDTO = cycleRanker.getCodebaseGraphDTO();
+            rankedClassCycles = cycleRanker.performCycleAnalysis(codebaseGraphDTO.getClassReferencesGraph());
+        } else {
+            codebaseGraphDTO = cycleRanker.generateClassReferencesGraph(excludeTests, testSourceDirectory);
         }
 
-        classGraph = cycleRanker.getClassReferencesGraph();
-        cycles = new CircularReferenceChecker<String, DefaultWeightedEdge>().getCycles(classGraph);
+        classGraph = codebaseGraphDTO.getClassReferencesGraph();
+        classCycles = new CircularReferenceChecker<String, DefaultWeightedEdge>().getCycles(classGraph);
+        Map<DefaultWeightedEdge, Integer> edgeCycleCounts = new HashMap<>();
 
         // Skip vertex and edge removal analysis if there are no cycles
-        if (!cycles.isEmpty()) {
+        if (!classCycles.isEmpty()) {
             // Identify vertexes to remove
             log.info("Identifying vertexes to remove");
             EnhancedParameterComputer<String, DefaultWeightedEdge> enhancedParameterComputer =
@@ -207,35 +211,18 @@ public class SimpleHtmlReport {
             PageRankFAS<String, DefaultWeightedEdge> pageRankFAS =
                     new PageRankFAS<>(classGraph, new SuperTypeToken<>() {});
             edgesToRemove = pageRankFAS.computeFeedbackArcSet();
-        }
 
-        // capture the number of cycles each edge to remove is in
-        Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts = new HashMap<>();
-        for (DefaultWeightedEdge edgeToRemove : edgesToRemove) {
-            int cycleCount = 0;
-            for (AsSubgraph<String, DefaultWeightedEdge> cycle : cycles.values()) {
-                if (cycle.containsEdge(edgeToRemove)) {
-                    cycleCount++;
+            // capture the number of cycles each edge to remove is in
+            for (DefaultWeightedEdge edgeToRemove : edgesToRemove) {
+                int cycleCount = 0;
+                for (AsSubgraph<String, DefaultWeightedEdge> cycle : classCycles.values()) {
+                    if (cycle.containsEdge(edgeToRemove)) {
+                        cycleCount++;
+                    }
                 }
+                edgeCycleCounts.put(edgeToRemove, cycleCount);
             }
-            edgeToRemoveCycleCounts.put(edgeToRemove, cycleCount);
         }
-
-        // int edgeWeight = (int) classGraph.getEdgeWeight(defaultWeightedEdge);
-        // map sources to CycleNodes to get paths and get churn in try/finally block below
-        Map<DefaultWeightedEdge, CycleNode> sourceNodeInfos = new HashMap<>();
-        Map<DefaultWeightedEdge, CycleNode> targetNodeInfos = new HashMap<>();
-        for (DefaultWeightedEdge defaultWeightedEdge : edgesToRemove) {
-            String edgeSource = classGraph.getEdgeSource(defaultWeightedEdge);
-            CycleNode sourceNode = cycleRanker.classToCycleNode(edgeSource);
-            sourceNodeInfos.put(defaultWeightedEdge, sourceNode);
-
-            String edgeTarget = classGraph.getEdgeTarget(defaultWeightedEdge);
-            CycleNode targetNode = cycleRanker.classToCycleNode(edgeTarget);
-            targetNodeInfos.put(defaultWeightedEdge, targetNode);
-        }
-
-        List<RankedDisharmony> edgeDisharmonies = List.of();
 
         // Ordered (type, anchorId, displayTitle, isMethodLevel) for all disharmonies
         final List<DisharmonySpec> disharmonySpecs = List.of(
@@ -259,11 +246,11 @@ public class SimpleHtmlReport {
 
         log.info("Identifying Object Oriented Disharmonies");
 
-        CodebaseGraphDTO codebaseGraphDTO = cycleRanker.getCodebaseGraphDTO();
+        List<RankedDisharmony> edgeDisharmonies = List.of();
         try (CostBenefitCalculator costBenefitCalculator =
                 new CostBenefitCalculator(projectBaseDir, codebaseGraphDTO.getClassToSourceFilePathMapping())) {
             edgeDisharmonies = costBenefitCalculator.calculateSourceNodeCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, codebaseGraphDTO, vertexesToRemove);
+                    classGraph, edgeCycleCounts, codebaseGraphDTO, vertexesToRemove);
 
             for (DisharmonySpec spec : disharmonySpecs) {
                 List<DisharmonyInstance> instances = spec.methodLevel()
@@ -287,7 +274,7 @@ public class SimpleHtmlReport {
         // - Provide guidance on where to move the method if one is in the list to remove
 
         boolean hasAnyDisharmony =
-                !edgesToRemove.isEmpty() || !rankedCycles.isEmpty() || !rankedDisharmoniesByAnchor.isEmpty();
+                !edgesToRemove.isEmpty() || !rankedClassCycles.isEmpty() || !rankedDisharmoniesByAnchor.isEmpty();
 
         String repoUrl;
         try (GitLogReader glr = new GitLogReader(new File(projectBaseDir))) {
@@ -308,7 +295,7 @@ public class SimpleHtmlReport {
         }
 
         stringBuilder.append("<header>\n" + "<nav>\n" + " <ul>\n");
-        stringBuilder.append(createMenu(disharmonySpecs, rankedDisharmoniesByAnchor, rankedCycles));
+        stringBuilder.append(createMenu(disharmonySpecs, rankedDisharmoniesByAnchor, rankedClassCycles));
         stringBuilder.append("</ul>\n" + "</nav>\n" + "</header>\n");
 
         log.info("Generating HTML Report");
@@ -332,8 +319,8 @@ public class SimpleHtmlReport {
             }
         }
 
-        if (!rankedCycles.isEmpty()) {
-            stringBuilder.append(renderCycles(rankedCycles, repoUrl, codebaseGraphDTO));
+        if (!rankedClassCycles.isEmpty()) {
+            stringBuilder.append(renderCycles(rankedClassCycles, repoUrl, codebaseGraphDTO));
         }
 
         log.debug(stringBuilder.toString());
@@ -394,7 +381,7 @@ public class SimpleHtmlReport {
                 "<div style=\"text-align: center;\"><a id=\"EDGES\"><h1>Relationship Removal Priority</h1></a></div>\n");
         stringBuilder.append("<h2 align=\"center\">Refactor Starting with Priority 1</h2>\n");
         stringBuilder.append("<div style=\"text-align: center;\">\n");
-        stringBuilder.append("Current Cycle Count: ").append(cycles.size()).append("<br>\n");
+        stringBuilder.append("Current Cycle Count: ").append(classCycles.size()).append("<br>\n");
 
         stringBuilder
                 .append("Number of Relationships to Remove: ")

--- a/report/src/test/java/org/hjug/refactorfirst/report/HtmlReportTest.java
+++ b/report/src/test/java/org/hjug/refactorfirst/report/HtmlReportTest.java
@@ -51,8 +51,7 @@ class HtmlReportTest {
 
         String cycleName = "Test";
         List<CycleNode> cycleNodes = new ArrayList<>();
-        RankedCycle rankedCycle =
-                new RankedCycle(cycleName, 0, classGraph.vertexSet(), classGraph.edgeSet(), 0, null, cycleNodes);
+        RankedCycle rankedCycle = new RankedCycle(cycleName, classGraph.vertexSet(), classGraph.edgeSet(), cycleNodes);
 
         HtmlReport htmlReport = new HtmlReport();
         CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);

--- a/report/src/test/java/org/hjug/refactorfirst/report/HtmlReportTest.java
+++ b/report/src/test/java/org/hjug/refactorfirst/report/HtmlReportTest.java
@@ -39,7 +39,7 @@ class HtmlReportTest {
     }
 
     @Test
-    void buildCycleDot() {
+    void buildClassCycleDot() {
         Graph<String, DefaultWeightedEdge> classGraph = new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
         classGraph.addVertex("A");
         classGraph.addVertex("B");
@@ -61,7 +61,7 @@ class HtmlReportTest {
         map.put("C", "/src/main/java/org/hjug/refactorfirst/C.java");
         when(dto.getClassToSourceFilePathMapping()).thenReturn(map);
         String repoUrl = "https://github.com/refactorfirst/RefactorFirst/blob";
-        String dot = htmlReport.buildCycleDot(classGraph, rankedCycle, repoUrl, dto);
+        String dot = htmlReport.buildClassCycleDot(classGraph, rankedCycle, repoUrl, dto);
         String expectedDot = "`strict digraph G {\n"
                 + "A -> B [ label = \"2\" weight = \"2\" ];\n"
                 + "B -> C [ label = \"1\" weight = \"1\" ];\n"


### PR DESCRIPTION
Analyze package cycles to identify which packages and package relationships need to go away in order to break apart cycles across packages
- Prioritizing relationships to remove based on the number of cycles each relationship exists in
- Listing the class relationships that are the source of the relationship between the cross-package relationship that needs to go away in order to remove the cross-package relationships that have been identified
- Generating DOT graph, 2D sigmaJs, and 3D Force Graph