### PR TITLE
Improve class relationship removal calculation

### DIFF
--- a/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/CodebaseGraphDTO.java
+++ b/codebase-graph-builder/src/main/java/org/hjug/graphbuilder/CodebaseGraphDTO.java
@@ -1,6 +1,5 @@
 package org.hjug.graphbuilder;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +25,6 @@ public class CodebaseGraphDTO {
 
     private final List<ClassDisharmony> classDisharmonies;
     private final List<MethodDisharmony> methodDisharmonies;
-    private final Map<String, Long> disharmonyCountByClass;
 
     public CodebaseGraphDTO(
             Graph<String, DefaultWeightedEdge> classReferencesGraph,
@@ -41,15 +39,6 @@ public class CodebaseGraphDTO {
         this.classToSourceFilePathMapping = classToSourceFilePathMapping;
         this.classDisharmonies = classDisharmonies;
         this.methodDisharmonies = methodDisharmonies;
-        this.disharmonyCountByClass = buildDisharmonyIndex(classDisharmonies, methodDisharmonies);
-    }
-
-    private static Map<String, Long> buildDisharmonyIndex(
-            List<ClassDisharmony> classDisharmonies, List<MethodDisharmony> methodDisharmonies) {
-        Map<String, Long> counts = new HashMap<>();
-        classDisharmonies.forEach(d -> counts.merge(d.getMetrics().getClassName(), 1L, Long::sum));
-        methodDisharmonies.forEach(m -> counts.merge(m.getClassName(), 1L, Long::sum));
-        return counts;
     }
 
     public List<ClassDisharmony> getClassDisharmoniesOfType(String disharmonyType) {
@@ -62,9 +51,5 @@ public class CodebaseGraphDTO {
         return methodDisharmonies.stream()
                 .filter(d -> disharmonyType.equals(d.getDisharmonyType()))
                 .collect(Collectors.toList());
-    }
-
-    public long getClassDisharmonyCountForClass(String classFqn) {
-        return disharmonyCountByClass.getOrDefault(classFqn, 0L);
     }
 }

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
@@ -332,8 +332,13 @@ public class CostBenefitCalculator implements AutoCloseable {
             Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts,
             CodebaseGraphDTO dto,
             Set<String> vertexesToRemove,
-            Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles) {
+            Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles,
+            List<RankedDisharmony> packageRelationshipDisharmonies) {
         List<RankedDisharmony> edgesThatNeedToBeRemoved = new ArrayList<>();
+
+        Set<DefaultWeightedEdge> packageEdgesToRemove = packageRelationshipDisharmonies.stream()
+                .map(RankedDisharmony::getEdge)
+                .collect(Collectors.toSet());
 
         for (DefaultWeightedEdge edge : classGraph.edgeSet()) {
             // shouldn't have to check for null edges & counts :-(
@@ -352,7 +357,8 @@ public class CostBenefitCalculator implements AutoCloseable {
                     (int) classGraph.getEdgeWeight(edge),
                     sourceNodeShouldBeRemoved,
                     targetNodeShouldBeRemoved,
-                    getPackageCycleCount(edgeSource, edgeTarget, dto, packageCycles));
+                    getPackageCycleCount(edgeSource, edgeTarget, dto, packageCycles),
+                    packageRelationshipShouldBeRemoved(edgeSource, edgeTarget, dto, packageEdgesToRemove));
 
             edgesThatNeedToBeRemoved.add(edgeThatNeedsToBeRemoved);
         }
@@ -400,6 +406,19 @@ public class CostBenefitCalculator implements AutoCloseable {
     }
 
     /**
+     * Determines whether the package-level relationship corresponding to the given class (or package) edge is
+     * itself one of the package edges selected for removal, based on membership in the already-computed package
+     * relationship disharmonies.
+     */
+    private static boolean packageRelationshipShouldBeRemoved(
+            String edgeSource, String edgeTarget, CodebaseGraphDTO dto, Set<DefaultWeightedEdge> packageEdgesToRemove) {
+        String sourcePackage = toPackageName(edgeSource, dto);
+        String targetPackage = toPackageName(edgeTarget, dto);
+        DefaultWeightedEdge packageEdge = dto.getPackageReferencesGraph().getEdge(sourcePackage, targetPackage);
+        return packageEdge != null && packageEdgesToRemove.contains(packageEdge);
+    }
+
+    /**
      * The vertex may already be a package name (when classGraph is actually a package graph) or a fully-qualified
      * class name, in which case the containing package is derived from it.
      */
@@ -420,8 +439,11 @@ public class CostBenefitCalculator implements AutoCloseable {
                 .reversed()
                 // then by weight, with lowest weight edges bubbling to the top
                 .thenComparingInt(RankedDisharmony::getEffortRank)
-                // then by package cycle count, with classes in more package cycles bubbling to the top
+                // then by whether the underlying package relationship should also be removed, true before false
                 // multiplying by -1 reverses the sort order (reverse doesn't work in chained comparators)
+                .thenComparingInt(
+                        rankedDisharmony -> -1 * (rankedDisharmony.isPackageRelationshipShouldBeRemoved() ? 1 : 0))
+                // then by package cycle count, with classes in more package cycles bubbling to the top
                 .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getPackageCycleCount())
                 // then if the source node is in the list of nodes to be removed
                 .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getSourceNodeShouldBeRemoved())

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/CostBenefitCalculator.java
@@ -27,6 +27,7 @@ import org.hjug.metrics.DisharmonyInstance;
 import org.hjug.metrics.DisharmonyRanker;
 import org.hjug.metrics.rules.CBORule;
 import org.jgrapht.Graph;
+import org.jgrapht.graph.AsSubgraph;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
 @Slf4j
@@ -330,7 +331,8 @@ public class CostBenefitCalculator implements AutoCloseable {
             Graph<String, DefaultWeightedEdge> classGraph,
             Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts,
             CodebaseGraphDTO dto,
-            Set<String> vertexesToRemove) {
+            Set<String> vertexesToRemove,
+            Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles) {
         List<RankedDisharmony> edgesThatNeedToBeRemoved = new ArrayList<>();
 
         for (DefaultWeightedEdge edge : classGraph.edgeSet()) {
@@ -350,8 +352,7 @@ public class CostBenefitCalculator implements AutoCloseable {
                     (int) classGraph.getEdgeWeight(edge),
                     sourceNodeShouldBeRemoved,
                     targetNodeShouldBeRemoved,
-                    dto.getClassDisharmonyCountForClass(edgeSource),
-                    dto.getClassDisharmonyCountForClass(edgeTarget));
+                    getPackageCycleCount(edgeSource, edgeTarget, dto, packageCycles));
 
             edgesThatNeedToBeRemoved.add(edgeThatNeedsToBeRemoved);
         }
@@ -376,6 +377,42 @@ public class CostBenefitCalculator implements AutoCloseable {
         return edgesThatNeedToBeRemoved;
     }
 
+    /**
+     * Counts how many package cycles contain the package-level relationship corresponding to the given class (or
+     * package) edge - i.e. cycles where the edge between the source's and target's packages is itself part of the
+     * cycle, not merely cycles that happen to contain one of the endpoints.
+     */
+    private static int getPackageCycleCount(
+            String edgeSource,
+            String edgeTarget,
+            CodebaseGraphDTO dto,
+            Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles) {
+        String sourcePackage = toPackageName(edgeSource, dto);
+        String targetPackage = toPackageName(edgeTarget, dto);
+
+        int packageCycleCount = 0;
+        for (AsSubgraph<String, DefaultWeightedEdge> packageCycle : packageCycles.values()) {
+            if (packageCycle.containsEdge(sourcePackage, targetPackage)) {
+                packageCycleCount++;
+            }
+        }
+        return packageCycleCount;
+    }
+
+    /**
+     * The vertex may already be a package name (when classGraph is actually a package graph) or a fully-qualified
+     * class name, in which case the containing package is derived from it.
+     */
+    private static String toPackageName(String vertex, CodebaseGraphDTO dto) {
+        if (dto.getPackageReferencesGraph().containsVertex(vertex)) {
+            return vertex;
+        } else if (vertex.contains(".")) {
+            return vertex.substring(0, vertex.lastIndexOf('.'));
+        } else {
+            return "";
+        }
+    }
+
     static void sortEdgesThatNeedToBeRemoved(List<RankedDisharmony> rankedDisharmonies) {
         // Sort by impact value
         // Order by cycle count reversed (highest count bubbles to the top)
@@ -383,11 +420,10 @@ public class CostBenefitCalculator implements AutoCloseable {
                 .reversed()
                 // then by weight, with lowest weight edges bubbling to the top
                 .thenComparingInt(RankedDisharmony::getEffortRank)
-                // then by disharmony count
-                .thenComparingInt(RankedDisharmony::getEdgeSourceDisharmonyCount)
-                .thenComparingInt(RankedDisharmony::getEdgeTargetDisharmonyCount)
-                // then if the source node is in the list of nodes to be removed
+                // then by package cycle count, with classes in more package cycles bubbling to the top
                 // multiplying by -1 reverses the sort order (reverse doesn't work in chained comparators)
+                .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getPackageCycleCount())
+                // then if the source node is in the list of nodes to be removed
                 .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getSourceNodeShouldBeRemoved())
                 // then if the target node is in the list of nodes to be removed
                 .thenComparingInt(rankedDisharmony -> -1 * rankedDisharmony.getTargetNodeShouldBeRemoved()));

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
@@ -45,6 +45,7 @@ public class RankedDisharmony {
     private int targetNodeShouldBeRemoved;
     private String edgeTargetClass;
     private Integer packageCycleCount;
+    private boolean packageRelationshipShouldBeRemoved;
 
     public RankedDisharmony(GodClass godClass, ScmLogInfo scmLogInfo) {
         path = scmLogInfo.getPath();
@@ -108,12 +109,14 @@ public class RankedDisharmony {
             int weight,
             boolean sourceNodeShouldBeRemoved,
             boolean targetNodeShouldBeRemoved,
-            int packageCycleCount) {
+            int packageCycleCount,
+            boolean packageRelationshipShouldBeRemoved) {
 
         className = edgeSource;
         this.edge = edge;
         this.cycleCount = cycleCount;
         this.packageCycleCount = packageCycleCount;
+        this.packageRelationshipShouldBeRemoved = packageRelationshipShouldBeRemoved;
         effortRank = weight;
         this.sourceNodeShouldBeRemoved = sourceNodeShouldBeRemoved ? 1 : 0;
         this.targetNodeShouldBeRemoved = targetNodeShouldBeRemoved ? 1 : 0;

--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
@@ -44,8 +44,7 @@ public class RankedDisharmony {
     private int sourceNodeShouldBeRemoved;
     private int targetNodeShouldBeRemoved;
     private String edgeTargetClass;
-    private Integer edgeSourceDisharmonyCount;
-    private Integer edgeTargetDisharmonyCount;
+    private Integer packageCycleCount;
 
     public RankedDisharmony(GodClass godClass, ScmLogInfo scmLogInfo) {
         path = scmLogInfo.getPath();
@@ -109,14 +108,12 @@ public class RankedDisharmony {
             int weight,
             boolean sourceNodeShouldBeRemoved,
             boolean targetNodeShouldBeRemoved,
-            long sourceDisharmonyCount,
-            long targetDisharmonyCount) {
+            int packageCycleCount) {
 
         className = edgeSource;
         this.edge = edge;
         this.cycleCount = cycleCount;
-        edgeSourceDisharmonyCount = Math.toIntExact(sourceDisharmonyCount);
-        edgeTargetDisharmonyCount = Math.toIntExact(targetDisharmonyCount);
+        this.packageCycleCount = packageCycleCount;
         effortRank = weight;
         this.sourceNodeShouldBeRemoved = sourceNodeShouldBeRemoved ? 1 : 0;
         this.targetNodeShouldBeRemoved = targetNodeShouldBeRemoved ? 1 : 0;

--- a/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
+++ b/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
@@ -1,7 +1,6 @@
 package org.hjug.cbc;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +14,7 @@ import org.hjug.git.ScmLogInfo;
 import org.hjug.graphbuilder.CodebaseGraphDTO;
 import org.hjug.metrics.Disharmony;
 import org.jetbrains.annotations.NotNull;
+import org.jgrapht.graph.AsSubgraph;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 import org.junit.jupiter.api.*;
@@ -154,10 +154,11 @@ class CostBenefitCalculatorTest {
                 git.getRepository().getDirectory().getParent(), scmLogInfos)) {
 
             CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
-            when(dto.getClassDisharmonyCountForClass(any())).thenReturn(0L);
+            when(dto.getPackageReferencesGraph())
+                    .thenReturn(new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class));
 
             List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove);
+                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap());
 
             Assertions.assertEquals(2, disharmonies.size());
 
@@ -176,7 +177,7 @@ class CostBenefitCalculatorTest {
             Assertions.assertEquals(0, classC.getSourceNodeShouldBeRemoved());
             Assertions.assertEquals(1, classC.getTargetNodeShouldBeRemoved());
             Assertions.assertEquals(2, classC.getPriority().intValue());
-            Assertions.assertEquals(0, classC.getEdgeSourceDisharmonyCount());
+            Assertions.assertEquals(0, classC.getPackageCycleCount());
         }
     }
 
@@ -226,16 +227,80 @@ class CostBenefitCalculatorTest {
                 git.getRepository().getDirectory().getParent(), scmLogInfos)) {
 
             CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
-            when(dto.getClassDisharmonyCountForClass(any())).thenReturn(0L).thenReturn(1L);
+            when(dto.getPackageReferencesGraph())
+                    .thenReturn(new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class));
 
             List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove);
+                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap());
 
             Assertions.assertEquals(2, disharmonies.size());
-            Assertions.assertEquals(0, disharmonies.get(0).getEdgeSourceDisharmonyCount());
+            Assertions.assertEquals(0, disharmonies.get(0).getPackageCycleCount());
             Assertions.assertEquals(1, disharmonies.get(0).getPriority().intValue());
             Assertions.assertEquals(2, disharmonies.get(1).getPriority().intValue());
-            Assertions.assertEquals(1, disharmonies.get(1).getEdgeSourceDisharmonyCount());
+            Assertions.assertEquals(0, disharmonies.get(1).getPackageCycleCount());
+        }
+    }
+
+    @Test
+    void calculateRelationshipCostBenefitValues_packageCycleCountReflectsRelationshipNotJustSourcePackage()
+            throws Exception {
+
+        writeFile(hudsonPath + "Placeholder.java", "public class Placeholder {}");
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("initial commit").call();
+
+        SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> packageGraph =
+                new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        packageGraph.addVertex("pkga");
+        packageGraph.addVertex("pkgb");
+        packageGraph.addVertex("pkgc");
+        packageGraph.addVertex("pkgd");
+        packageGraph.addEdge("pkga", "pkgb");
+        packageGraph.addEdge("pkgb", "pkgc");
+        packageGraph.addEdge("pkgc", "pkga");
+        // dangling relationship: pkga depends on pkgd, but pkgd is not part of the pkga/pkgb/pkgc cycle
+        packageGraph.addEdge("pkga", "pkgd");
+
+        Map<String, AsSubgraph<String, DefaultWeightedEdge>> packageCycles = new HashMap<>();
+        packageCycles.put("cycle1", new AsSubgraph<>(packageGraph, Set.of("pkga", "pkgb", "pkgc")));
+
+        SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> classGraph =
+                new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        classGraph.addVertex("pkga.Foo");
+        classGraph.addVertex("pkgb.Bar");
+        classGraph.addVertex("pkgc.Baz");
+        classGraph.addVertex("pkgd.Qux");
+
+        DefaultWeightedEdge fooToBar = classGraph.addEdge("pkga.Foo", "pkgb.Bar");
+        DefaultWeightedEdge barToBaz = classGraph.addEdge("pkgb.Bar", "pkgc.Baz");
+        DefaultWeightedEdge bazToFoo = classGraph.addEdge("pkgc.Baz", "pkga.Foo");
+        DefaultWeightedEdge fooToQux = classGraph.addEdge("pkga.Foo", "pkgd.Qux");
+
+        Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts = new HashMap<>();
+        edgeToRemoveCycleCounts.put(fooToBar, 1);
+        edgeToRemoveCycleCounts.put(barToBaz, 1);
+        edgeToRemoveCycleCounts.put(bazToFoo, 1);
+        edgeToRemoveCycleCounts.put(fooToQux, 1);
+
+        CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
+        when(dto.getPackageReferencesGraph()).thenReturn(packageGraph);
+
+        try (CostBenefitCalculator costBenefitCalculator =
+                new CostBenefitCalculator(git.getRepository().getDirectory().getParent(), new HashMap<>())) {
+
+            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
+                    classGraph, edgeToRemoveCycleCounts, dto, Collections.emptySet(), packageCycles);
+
+            Map<DefaultWeightedEdge, RankedDisharmony> disharmoniesByEdge = new HashMap<>();
+            disharmonies.forEach(d -> disharmoniesByEdge.put(d.getEdge(), d));
+
+            Assertions.assertEquals(1, disharmoniesByEdge.get(fooToBar).getPackageCycleCount());
+            Assertions.assertEquals(1, disharmoniesByEdge.get(barToBaz).getPackageCycleCount());
+            Assertions.assertEquals(1, disharmoniesByEdge.get(bazToFoo).getPackageCycleCount());
+            // pkga is in cycle1, but the Foo -> Qux relationship itself is not - must not be counted
+            Assertions.assertEquals(0, disharmoniesByEdge.get(fooToQux).getPackageCycleCount());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -258,27 +323,27 @@ class CostBenefitCalculatorTest {
         logInfo5.setChangePronenessRank(5);
 
         // Create RankedDisharmony objects with different combinations
-        // Expected order after sorting: cycleCount desc, then sourceRemoved desc, then targetRemoved desc, then
-        // changeProneness desc
-        // cycle=5, source=0, target=0, change=5
+        // Expected order after sorting: cycleCount desc, then effortRank asc, then packageCycleCount desc,
+        // then sourceRemoved desc, then targetRemoved desc
+        // cycle=5, source=0, target=0, packageCycleCount=6
         RankedDisharmony disharmony1 =
-                new RankedDisharmony("Class1", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, false, false, 0, 0);
+                new RankedDisharmony("Class1", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, false, false, 6);
 
-        // cycle=5, source=1, target=0, change=3
+        // cycle=5, source=1, target=0, packageCycleCount=1
         RankedDisharmony disharmony2 =
-                new RankedDisharmony("Class2", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, true, false, 1, 1);
+                new RankedDisharmony("Class2", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, true, false, 1);
 
-        // cycle=3, source=0, target=1, change=8
+        // cycle=3, source=0, target=1, packageCycleCount=5
         RankedDisharmony disharmony3 =
-                new RankedDisharmony("Class3", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, true, 2, 2);
+                new RankedDisharmony("Class3", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, true, 5);
 
-        // cycle=3, source=0, target=0, change=2
+        // cycle=3, source=0, target=0, packageCycleCount=0
         RankedDisharmony disharmony4 =
-                new RankedDisharmony("Class4", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 6, 3);
+                new RankedDisharmony("Class4", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 0);
 
-        // cycle=3, source=0, target=0, change=5
+        // cycle=3, source=0, target=0, packageCycleCount=2
         RankedDisharmony disharmony5 =
-                new RankedDisharmony("Class5", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 5, 0);
+                new RankedDisharmony("Class5", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 2);
 
         List<RankedDisharmony> disharmonies =
                 Arrays.asList(disharmony4, disharmony2, disharmony1, disharmony3, disharmony5);
@@ -288,16 +353,16 @@ class CostBenefitCalculatorTest {
 
         // Verify the order
         // Order by cycle count reversed (highest count bubbles to the top)
+        // then Order by package cycle count (highest count bubbles to the top)
         // then Order by source node removed (source nodes needing to be removed bubble to the top)
-        // then Order by target node removed (target nodes needing to be removed bubble to the top)\
-        // then Order by change proneness (highest change proneness bubbles to the top)
+        // then Order by target node removed (target nodes needing to be removed bubble to the top)
         for (RankedDisharmony disharmony : disharmonies) {
             System.out.println(disharmony.getClassName() + " "
                     + disharmony.getCycleCount() + " "
                     + disharmony.getEffortRank() + " "
                     + disharmony.getSourceNodeShouldBeRemoved() + " "
                     + disharmony.getTargetNodeShouldBeRemoved() + " "
-                    + disharmony.getEdgeSourceDisharmonyCount());
+                    + disharmony.getPackageCycleCount());
         }
 
         RankedDisharmony orderedDisharmony0 = disharmonies.get(0);
@@ -306,7 +371,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony0.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony0.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony0.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(0, orderedDisharmony0.getEdgeSourceDisharmonyCount());
+        Assertions.assertEquals(6, orderedDisharmony0.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony1 = disharmonies.get(1);
         Assertions.assertEquals("Class2", orderedDisharmony1.getClassName());
@@ -314,7 +379,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony1.getEffortRank().intValue());
         Assertions.assertEquals(1, orderedDisharmony1.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony1.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(1, orderedDisharmony1.getEdgeSourceDisharmonyCount());
+        Assertions.assertEquals(1, orderedDisharmony1.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony2 = disharmonies.get(2);
         Assertions.assertEquals("Class3", orderedDisharmony2.getClassName());
@@ -322,7 +387,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony2.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony2.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(1, orderedDisharmony2.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(2, orderedDisharmony2.getEdgeSourceDisharmonyCount());
+        Assertions.assertEquals(5, orderedDisharmony2.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony3 = disharmonies.get(3);
         Assertions.assertEquals("Class5", orderedDisharmony3.getClassName());
@@ -330,7 +395,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(1, orderedDisharmony3.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony3.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony3.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(5, orderedDisharmony3.getEdgeSourceDisharmonyCount());
+        Assertions.assertEquals(2, orderedDisharmony3.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony4 = disharmonies.get(4);
         Assertions.assertEquals("Class4", orderedDisharmony4.getClassName());
@@ -338,7 +403,7 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(3, orderedDisharmony4.getCycleCount().intValue());
         Assertions.assertEquals(0, orderedDisharmony4.getSourceNodeShouldBeRemoved());
         Assertions.assertEquals(0, orderedDisharmony4.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(6, orderedDisharmony4.getEdgeSourceDisharmonyCount());
+        Assertions.assertEquals(0, orderedDisharmony4.getPackageCycleCount());
     }
 
     private void writeFile(String name, String content) throws IOException {

--- a/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
+++ b/cost-benefit-calculator/src/test/java/org/hjug/cbc/CostBenefitCalculatorTest.java
@@ -158,7 +158,7 @@ class CostBenefitCalculatorTest {
                     .thenReturn(new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class));
 
             List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap());
+                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap(), List.of());
 
             Assertions.assertEquals(2, disharmonies.size());
 
@@ -231,7 +231,7 @@ class CostBenefitCalculatorTest {
                     .thenReturn(new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class));
 
             List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap());
+                    classGraph, edgeToRemoveCycleCounts, dto, vertexesToRemove, Collections.emptyMap(), List.of());
 
             Assertions.assertEquals(2, disharmonies.size());
             Assertions.assertEquals(0, disharmonies.get(0).getPackageCycleCount());
@@ -289,7 +289,7 @@ class CostBenefitCalculatorTest {
                 new CostBenefitCalculator(git.getRepository().getDirectory().getParent(), new HashMap<>())) {
 
             List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, edgeToRemoveCycleCounts, dto, Collections.emptySet(), packageCycles);
+                    classGraph, edgeToRemoveCycleCounts, dto, Collections.emptySet(), packageCycles, List.of());
 
             Map<DefaultWeightedEdge, RankedDisharmony> disharmoniesByEdge = new HashMap<>();
             disharmonies.forEach(d -> disharmoniesByEdge.put(d.getEdge(), d));
@@ -301,6 +301,68 @@ class CostBenefitCalculatorTest {
             Assertions.assertEquals(0, disharmoniesByEdge.get(fooToQux).getPackageCycleCount());
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void calculateRelationshipCostBenefitValues_flagsClassEdgesWhosePackageRelationshipIsAlsoBeingRemoved()
+            throws Exception {
+
+        writeFile(hudsonPath + "Placeholder.java", "public class Placeholder {}");
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("initial commit").call();
+
+        SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> packageGraph =
+                new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        packageGraph.addVertex("pkga");
+        packageGraph.addVertex("pkgb");
+        packageGraph.addVertex("pkgc");
+        DefaultWeightedEdge pkgaToPkgb = packageGraph.addEdge("pkga", "pkgb");
+        packageGraph.addEdge("pkgb", "pkgc");
+
+        // Only pkga -> pkgb is flagged as a package relationship that needs to be removed
+        RankedDisharmony packageEdgeToRemove = new RankedDisharmony("pkga", pkgaToPkgb, 1, 1, false, false, 0, false);
+        List<RankedDisharmony> packageRelationshipDisharmonies = List.of(packageEdgeToRemove);
+
+        SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> classGraph =
+                new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        classGraph.addVertex("pkga.Foo");
+        classGraph.addVertex("pkgb.Bar");
+        classGraph.addVertex("pkgc.Baz");
+        classGraph.addVertex("pkga.Other");
+
+        // matches the removed package relationship pkga -> pkgb
+        DefaultWeightedEdge fooToBar = classGraph.addEdge("pkga.Foo", "pkgb.Bar");
+        // corresponds to pkgb -> pkgc, which is not in packageRelationshipDisharmonies
+        DefaultWeightedEdge barToBaz = classGraph.addEdge("pkgb.Bar", "pkgc.Baz");
+        // same-package relationship: no package edge exists at all
+        DefaultWeightedEdge fooToOther = classGraph.addEdge("pkga.Foo", "pkga.Other");
+
+        Map<DefaultWeightedEdge, Integer> edgeToRemoveCycleCounts = new HashMap<>();
+        edgeToRemoveCycleCounts.put(fooToBar, 1);
+        edgeToRemoveCycleCounts.put(barToBaz, 1);
+        edgeToRemoveCycleCounts.put(fooToOther, 1);
+
+        CodebaseGraphDTO dto = mock(CodebaseGraphDTO.class);
+        when(dto.getPackageReferencesGraph()).thenReturn(packageGraph);
+
+        try (CostBenefitCalculator costBenefitCalculator =
+                new CostBenefitCalculator(git.getRepository().getDirectory().getParent(), new HashMap<>())) {
+
+            List<RankedDisharmony> disharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
+                    classGraph,
+                    edgeToRemoveCycleCounts,
+                    dto,
+                    Collections.emptySet(),
+                    Collections.emptyMap(),
+                    packageRelationshipDisharmonies);
+
+            Map<DefaultWeightedEdge, RankedDisharmony> disharmoniesByEdge = new HashMap<>();
+            disharmonies.forEach(d -> disharmoniesByEdge.put(d.getEdge(), d));
+
+            Assertions.assertTrue(disharmoniesByEdge.get(fooToBar).isPackageRelationshipShouldBeRemoved());
+            Assertions.assertFalse(disharmoniesByEdge.get(barToBaz).isPackageRelationshipShouldBeRemoved());
+            Assertions.assertFalse(disharmoniesByEdge.get(fooToOther).isPackageRelationshipShouldBeRemoved());
         }
     }
 
@@ -323,27 +385,30 @@ class CostBenefitCalculatorTest {
         logInfo5.setChangePronenessRank(5);
 
         // Create RankedDisharmony objects with different combinations
-        // Expected order after sorting: cycleCount desc, then effortRank asc, then packageCycleCount desc,
+        // Expected order after sorting: cycleCount desc, then effortRank asc,
+        // then packageRelationshipShouldBeRemoved desc (true before false), then packageCycleCount desc,
         // then sourceRemoved desc, then targetRemoved desc
-        // cycle=5, source=0, target=0, packageCycleCount=6
-        RankedDisharmony disharmony1 =
-                new RankedDisharmony("Class1", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, false, false, 6);
+        // cycle=5, source=0, target=0, packageCycleCount=6, packageRelationshipShouldBeRemoved=false
+        RankedDisharmony disharmony1 = new RankedDisharmony(
+                "Class1", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, false, false, 6, false);
 
-        // cycle=5, source=1, target=0, packageCycleCount=1
-        RankedDisharmony disharmony2 =
-                new RankedDisharmony("Class2", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, true, false, 1);
+        // cycle=5, source=1, target=0, packageCycleCount=1, packageRelationshipShouldBeRemoved=false
+        RankedDisharmony disharmony2 = new RankedDisharmony(
+                "Class2", new org.jgrapht.graph.DefaultWeightedEdge(), 5, 1, true, false, 1, false);
 
-        // cycle=3, source=0, target=1, packageCycleCount=5
-        RankedDisharmony disharmony3 =
-                new RankedDisharmony("Class3", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, true, 5);
+        // cycle=3, source=0, target=1, packageCycleCount=5, packageRelationshipShouldBeRemoved=false
+        RankedDisharmony disharmony3 = new RankedDisharmony(
+                "Class3", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, true, 5, false);
 
-        // cycle=3, source=0, target=0, packageCycleCount=0
-        RankedDisharmony disharmony4 =
-                new RankedDisharmony("Class4", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 0);
+        // cycle=3, source=0, target=0, packageCycleCount=0, packageRelationshipShouldBeRemoved=false
+        RankedDisharmony disharmony4 = new RankedDisharmony(
+                "Class4", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 0, false);
 
-        // cycle=3, source=0, target=0, packageCycleCount=2
-        RankedDisharmony disharmony5 =
-                new RankedDisharmony("Class5", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 2);
+        // cycle=3, source=0, target=0, packageCycleCount=2, packageRelationshipShouldBeRemoved=true
+        // lower packageCycleCount than disharmony3, but packageRelationshipShouldBeRemoved=true must still
+        // bubble it ahead of disharmony3, proving the new sort clause is applied before packageCycleCount
+        RankedDisharmony disharmony5 = new RankedDisharmony(
+                "Class5", new org.jgrapht.graph.DefaultWeightedEdge(), 3, 1, false, false, 2, true);
 
         List<RankedDisharmony> disharmonies =
                 Arrays.asList(disharmony4, disharmony2, disharmony1, disharmony3, disharmony5);
@@ -381,21 +446,23 @@ class CostBenefitCalculatorTest {
         Assertions.assertEquals(0, orderedDisharmony1.getTargetNodeShouldBeRemoved());
         Assertions.assertEquals(1, orderedDisharmony1.getPackageCycleCount());
 
+        // Class5 has a lower packageCycleCount than Class3, but packageRelationshipShouldBeRemoved=true
+        // outranks packageCycleCount, so it bubbles ahead
         RankedDisharmony orderedDisharmony2 = disharmonies.get(2);
-        Assertions.assertEquals("Class3", orderedDisharmony2.getClassName());
+        Assertions.assertEquals("Class5", orderedDisharmony2.getClassName());
         Assertions.assertEquals(3, orderedDisharmony2.getCycleCount().intValue());
         Assertions.assertEquals(1, orderedDisharmony2.getEffortRank().intValue());
-        Assertions.assertEquals(0, orderedDisharmony2.getSourceNodeShouldBeRemoved());
-        Assertions.assertEquals(1, orderedDisharmony2.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(5, orderedDisharmony2.getPackageCycleCount());
+        Assertions.assertTrue(orderedDisharmony2.isPackageRelationshipShouldBeRemoved());
+        Assertions.assertEquals(2, orderedDisharmony2.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony3 = disharmonies.get(3);
-        Assertions.assertEquals("Class5", orderedDisharmony3.getClassName());
+        Assertions.assertEquals("Class3", orderedDisharmony3.getClassName());
         Assertions.assertEquals(3, orderedDisharmony3.getCycleCount().intValue());
         Assertions.assertEquals(1, orderedDisharmony3.getEffortRank().intValue());
         Assertions.assertEquals(0, orderedDisharmony3.getSourceNodeShouldBeRemoved());
-        Assertions.assertEquals(0, orderedDisharmony3.getTargetNodeShouldBeRemoved());
-        Assertions.assertEquals(2, orderedDisharmony3.getPackageCycleCount());
+        Assertions.assertEquals(1, orderedDisharmony3.getTargetNodeShouldBeRemoved());
+        Assertions.assertFalse(orderedDisharmony3.isPackageRelationshipShouldBeRemoved());
+        Assertions.assertEquals(5, orderedDisharmony3.getPackageCycleCount());
 
         RankedDisharmony orderedDisharmony4 = disharmonies.get(4);
         Assertions.assertEquals("Class4", orderedDisharmony4.getClassName());

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -303,9 +303,14 @@ public class SimpleHtmlReport {
         try (CostBenefitCalculator costBenefitCalculator =
                 new CostBenefitCalculator(projectBaseDir, codebaseGraphDTO.getClassToSourceFilePathMapping())) {
             packageRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    packageGraph, packageEdgeCycleCounts, codebaseGraphDTO, packagesToRemove, packageCycles);
+                    packageGraph, packageEdgeCycleCounts, codebaseGraphDTO, packagesToRemove, packageCycles, List.of());
             classRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, classEdgeCycleCounts, codebaseGraphDTO, classesToRemove, packageCycles);
+                    classGraph,
+                    classEdgeCycleCounts,
+                    codebaseGraphDTO,
+                    classesToRemove,
+                    packageCycles,
+                    packageRelationshipDisharmonies);
 
             for (DisharmonySpec spec : disharmonySpecs) {
                 List<DisharmonyInstance> instances = spec.methodLevel()
@@ -571,7 +576,12 @@ public class SimpleHtmlReport {
 
     private String[] getClassRelationshipDisharmonyTableHeadings() {
         return new String[] {
-            "Relationship", "Priority", "In Class<br>Cycles", "Relationship<br>Strength", "In Package<br>Cycles",
+            "Relationship",
+            "Priority",
+            "In Class<br>Cycles",
+            "Relationship<br>Strength",
+            "Also Remove<br>Package Relationship",
+            "In Package<br>Cycles",
         };
     }
 
@@ -583,11 +593,13 @@ public class SimpleHtmlReport {
 
     private String[] getClassRelationshipDisharmony(
             RankedDisharmony edgeInfo, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+        boolean removePkgRel = edgeInfo.isPackageRelationshipShouldBeRemoved();
         return new String[] {
             renderClassEdge(edgeInfo.getEdge(), repoUrl, codebaseGraphDTO),
             String.valueOf(edgeInfo.getPriority()),
             String.valueOf(edgeInfo.getCycleCount()),
             String.valueOf(edgeInfo.getEffortRank()),
+            removePkgRel ? "<strong>true</strong>" : String.valueOf(false),
             String.valueOf(edgeInfo.getPackageCycleCount()),
         };
     }

--- a/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/SimpleHtmlReport.java
@@ -302,10 +302,10 @@ public class SimpleHtmlReport {
         List<RankedDisharmony> packageRelationshipDisharmonies = List.of();
         try (CostBenefitCalculator costBenefitCalculator =
                 new CostBenefitCalculator(projectBaseDir, codebaseGraphDTO.getClassToSourceFilePathMapping())) {
-            classRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    classGraph, classEdgeCycleCounts, codebaseGraphDTO, classesToRemove);
             packageRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
-                    packageGraph, packageEdgeCycleCounts, codebaseGraphDTO, packagesToRemove);
+                    packageGraph, packageEdgeCycleCounts, codebaseGraphDTO, packagesToRemove, packageCycles);
+            classRelationshipDisharmonies = costBenefitCalculator.calculateRelationshipCostBenefitValues(
+                    classGraph, classEdgeCycleCounts, codebaseGraphDTO, classesToRemove, packageCycles);
 
             for (DisharmonySpec spec : disharmonySpecs) {
                 List<DisharmonyInstance> instances = spec.methodLevel()
@@ -316,7 +316,6 @@ public class SimpleHtmlReport {
                             spec.anchorId(), costBenefitCalculator.calculateDisharmonyCostBenefitValues(instances));
                 }
             }
-
         } catch (Exception e) {
             log.error("Error running analysis.");
             throw new RuntimeException(e);
@@ -358,7 +357,8 @@ public class SimpleHtmlReport {
 
         stringBuilder.append("<br/>\n");
         if (!classRelationshipDisharmonies.isEmpty()) {
-            stringBuilder.append(renderClassEdgeDisharmonies(classRelationshipDisharmonies, repoUrl, codebaseGraphDTO));
+            stringBuilder.append(renderClassEdgeDisharmonies(
+                    classRelationshipDisharmonies, packageRelationshipDisharmonies, repoUrl, codebaseGraphDTO));
             stringBuilder.append("<br/>\n" + "<br/>\n" + "<br/>\n" + "<br/>\n" + "<hr/>\n" + "<br/>\n" + "<br/>\n");
         }
 
@@ -467,7 +467,10 @@ public class SimpleHtmlReport {
     }
 
     private String renderClassEdgeDisharmonies(
-            List<RankedDisharmony> edgeDisharmonies, String repoUrl, CodebaseGraphDTO codebaseGraphDTO) {
+            List<RankedDisharmony> classRelationshipDisharmonies,
+            List<RankedDisharmony> packageRelationshipDisharmonies,
+            String repoUrl,
+            CodebaseGraphDTO codebaseGraphDTO) {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(
@@ -499,7 +502,7 @@ public class SimpleHtmlReport {
 
         stringBuilder.append("<tbody>\n");
 
-        for (RankedDisharmony edge : edgeDisharmonies) {
+        for (RankedDisharmony edge : classRelationshipDisharmonies) {
             stringBuilder.append("<tr>\n");
 
             for (String rowData : getClassRelationshipDisharmony(edge, repoUrl, codebaseGraphDTO)) {
@@ -568,12 +571,7 @@ public class SimpleHtmlReport {
 
     private String[] getClassRelationshipDisharmonyTableHeadings() {
         return new String[] {
-            "Relationship",
-            "Priority",
-            "In Cycles",
-            "Edge<br>Weight",
-            "Source<br>Disharmony Count",
-            "Target<br>Disharmony Count",
+            "Relationship", "Priority", "In Class<br>Cycles", "Relationship<br>Strength", "In Package<br>Cycles",
         };
     }
 
@@ -590,8 +588,7 @@ public class SimpleHtmlReport {
             String.valueOf(edgeInfo.getPriority()),
             String.valueOf(edgeInfo.getCycleCount()),
             String.valueOf(edgeInfo.getEffortRank()),
-            String.valueOf(edgeInfo.getEdgeSourceDisharmonyCount()),
-            String.valueOf(edgeInfo.getEdgeTargetDisharmonyCount()),
+            String.valueOf(edgeInfo.getPackageCycleCount()),
         };
     }
 


### PR DESCRIPTION
Improve class relationship removal calculation to incorporate number of package cycles the relationship is involved in and if the relationship between classes that needs to be removed directly contributes to a package relationship that needs to be removed