### PR TITLE
Replace Charset.defaultCharset() with StandardCharsets.UTF_8

### DIFF
--- a/report/src/main/java/org/hjug/refactorfirst/report/ReportWriter.java
+++ b/report/src/main/java/org/hjug/refactorfirst/report/ReportWriter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -162,7 +162,7 @@ public final class ReportWriter {
             try {
                 try (SeekableByteChannel channel = directory.newByteChannel(temporaryName, options);
                         BufferedWriter writer = new BufferedWriter(
-                                new OutputStreamWriter(Channels.newOutputStream(channel), Charset.defaultCharset()))) {
+                                new OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8))) {
                     writer.write(content);
                 }
                 directory.move(temporaryName, directory, reportName);
@@ -218,7 +218,7 @@ public final class ReportWriter {
             try {
                 try (SeekableByteChannel channel = Files.newByteChannel(temporaryName, options);
                         BufferedWriter writer = new BufferedWriter(
-                                new OutputStreamWriter(Channels.newOutputStream(channel), Charset.defaultCharset()))) {
+                                new OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8))) {
                     writer.write(content);
                 }
                 // Verify temp file is not a symlink before move

--- a/report/src/test/java/org/hjug/refactorfirst/report/ReportWriterTest.java
+++ b/report/src/test/java/org/hjug/refactorfirst/report/ReportWriterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
@@ -278,5 +279,21 @@ class ReportWriterTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> ReportWriter.containReportDirectory(tempDir.toFile(), "linked/site"));
+    }
+
+    @Test
+    void writeReportToDisk_emitsUtf8ForNonAsciiContent(@TempDir Path tempDir) throws IOException {
+        String nonAsciiContent = "café 漢字 😀";
+        Path outputDir = tempDir.resolve("output");
+        Files.createDirectories(outputDir);
+
+        ReportWriter.writeReportToDisk(outputDir.toString(), "test.html", nonAsciiContent);
+
+        Path outputFile = outputDir.resolve("test.html");
+        assertTrue(Files.exists(outputFile));
+
+        byte[] writtenBytes = Files.readAllBytes(outputFile);
+        byte[] expectedBytes = nonAsciiContent.getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(expectedBytes, writtenBytes, "ReportWriter must emit UTF-8 bytes");
     }
 }


### PR DESCRIPTION
Replace Charset.defaultCharset() with StandardCharsets.UTF_8.  Suggested by CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reports are now consistently written using UTF-8 encoding across all supported write paths, improving compatibility across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->